### PR TITLE
FIX: Mixup of .cvmfscatalog and .cvmfsdirtab

### DIFF
--- a/cpt-repo.tex
+++ b/cpt-repo.tex
@@ -330,8 +330,8 @@ Those paths may contain shell wildcards such as asterisk (\texttt{*}) and questi
 This is useful for specifying patterns for creating nested catalogs as new files are installed. 
 A very good use of the patterns is to identify directories where software releases will be installed.  
 
-In addition, lines in \texttt{.cvmfscatalog} that begin with an exclamation point (\texttt{!}) are shell patterns that will be excluded from those matched by lines without an exclamation point.
-For example a \texttt{.cvmfscatalog} might contain these lines for the repository of the previous subsection:
+In addition, lines in \texttt{.cvmfsdirtab} that begin with an exclamation point (\texttt{!}) are shell patterns that will be excluded from those matched by lines without an exclamation point.
+For example a \texttt{.cvmfsdirtab} might contain these lines for the repository of the previous subsection:
 \begin{verbatim}
 /software/*
 /software/*/*


### PR DESCRIPTION
Wrongly references to `.cvmfscatalog` instead of `.cvmfsdirtab`. Thanks to Catalin.
