### PR TITLE
Description of CVMFS Server Infrastructure

### DIFF
--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -11,6 +11,7 @@ A \cvmfs\ server installation depends on some environment setup and tools to be 
 \item Backend storage location available through HTTP
 \item \textbf{cvmfs} and \textbf{cvmfs-server} packages installed
 \end{itemize}
+\pagebreak
 
 \section{Local Backend Storage Infrastructure}
 \cvmfs\ stores the entire repository content (file content and meta-data catalogs) into a content addressable storage (CAS).
@@ -29,7 +30,8 @@ Note that the data volume of the spool area can grow very large for massive repo
 \pagebreak
 
 \section{Repository Configuration Directory}
-The authoritative configuration of a \cvmfs\ repository is located in \texttt{/etc/cvmfs/repositories.d} and should only be writable by the administrator.
+The authoritative configuration of a \cvmfs\ repository is located in \linebreak
+\texttt{/etc/cvmfs/repositories.d} and should only be writable by the administrator.
 Furthermore the repository's keychain is located in \texttt{/etc/cvmfs/keys} and follows the naming convention \texttt{<fqrn>.crt} for the certificate, \texttt{<fqrn>.key} for the repository's private key and \texttt{<fqrn>.pub} for the public key.
 All of those files can be symlinked somewhere else if necessary.
 

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -1,4 +1,13 @@
 \chapter{\cvmfs\ Server Infrastructure}
 \label{apx:serverinfrastructure}
 
-tbd
+This is trying to be a full documentation of a \cvmfs\ server setup including the infrastructure necessary for an individual repository.
+It is highly recommended to first consult Section~\ref{sct:repoanatomy} for a more general overview of the involved directory structure.
+
+\section{Prerequisites}
+A \cvmfs\ server installation depends on some environment setup and tools to be in place:
+\begin{itemize}
+\item \aufs\ support in the kernel (see Section~\ref{sct:customkernelinstall})
+\item Backend storage location available through HTTP
+\item \textbf{cvmfs} and \textbf{cvmfs-server} packages installed
+\end{itemize}

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -35,3 +35,26 @@ All of those files can be symlinked somewhere else if necessary.
 
 \LTXtable{\textwidth}{figures/tabrepoconfiganatomy.tex}
 \pagebreak
+
+\section{Environment Setup}
+Apart from file and directory locations a \cvmfs\ server installation depends on a few environment configurations.
+Most notably the possibility to access the backend storage through HTTP and to allow for mounting of both the \cvmfs\ client at \texttt{/var/spool/cvmfs/<fqrn>/rdonly} and \aufs\ on \texttt{/cvmfs/<fqrn>}.
+
+Granting HTTP access can happen in various ways and depends on the chosen backend storage type.
+For an S3 hosted backend storage, the \cvmfs\ client can usually be directly pointed to the S3 bucket used for storage (see Section~\ref{sct:s3storagesetup} for details).
+In case of a local file system backend any web server can be used for this purpose.
+By default \cvmfs\ assumes Apache and uses that automatically.
+
+Internally the \cvmfs\ server uses a SUID binary (i.e. \texttt{cvmfs\_suid\_helper}) to manipulate its mount points.
+This is necessary, since transactional \cvmfs\ commands must be accessible to the repository owner that is usually different from root.
+Both the mount directives for \texttt{/var/spool/cvmfs/<fqrn>/rdonly} and \texttt{/cvmfs/<fqrn>} must be placed into \texttt{/etc/fstab} for this reason.
+By default \cvmfs\ uses the following entries for these mount points:
+
+\begin{verbatim}
+cvmfs2#<fqrn> /var/spool/cvmfs/<fqrn>/rdonly fuse \
+allow_other,config=/etc/cvmfs/repositories.d/<fqrn>/client.conf: \
+/var/spool/cvmfs/<fqrn>/client.local,cvmfs_suid 0 0
+
+aufs_<fqrn> /cvmfs/<fqrn> aufs br=/var/spool/cvmfs/<fqrn>/scratch=rw: \
+/var/spool/cvmfs/<fqrn>/rdonly=rr,udba=none,ro 0 0
+\end{verbatim}

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -18,3 +18,11 @@ This storage can either be a file system at \texttt{/srv/cvmfs} or an S3 compati
 In the former case the contents of \texttt{/srv/cvmfs} are as follows:
 
 \LTXtable{\textwidth}{figures/tablocalstorageanatomy.tex}
+\pagebreak
+
+\section{Server Spool Area of a Repository (Stratum0)}
+The spool area of a repository contains transaction infrastructure and scratch area of a Stratum0 or specifically a release manager machine installation.
+It is always located inside \texttt{/var/spool/cvmfs} with directories for individual repositories.
+Note that the data volume of the spool area can grow very large for massive repository updates since it contains the writable AUFS branch and a \cvmfs\ client cache directory.
+
+\LTXtable{\textwidth}{figures/tabrepospoolanatomy.tex}

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -9,6 +9,7 @@ A \cvmfs\ server installation depends on some environment setup and tools to be 
 \begin{itemize}
 \item \aufs\ support in the kernel (see Section~\ref{sct:customkernelinstall})
 \item Backend storage location available through HTTP
+\item Backend storage accessible at \texttt{/srv/cvmfs/...} (unless stored on S3)
 \item \textbf{cvmfs} and \textbf{cvmfs-server} packages installed
 \end{itemize}
 \pagebreak

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -11,3 +11,10 @@ A \cvmfs\ server installation depends on some environment setup and tools to be 
 \item Backend storage location available through HTTP
 \item \textbf{cvmfs} and \textbf{cvmfs-server} packages installed
 \end{itemize}
+
+\section{Local Backend Storage Infrastructure}
+\cvmfs\ stores the entire repository content (file content and meta-data catalogs) into a content addressable storage (CAS).
+This storage can either be a file system at \texttt{/srv/cvmfs} or an S3 compatible key-value storage system (see Section~\ref{sct:s3storagesetup} for details).
+In the former case the contents of \texttt{/srv/cvmfs} are as follows:
+
+\LTXtable{\textwidth}{figures/tablocalstorageanatomy.tex}

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -26,3 +26,12 @@ It is always located inside \texttt{/var/spool/cvmfs} with directories for indiv
 Note that the data volume of the spool area can grow very large for massive repository updates since it contains the writable AUFS branch and a \cvmfs\ client cache directory.
 
 \LTXtable{\textwidth}{figures/tabrepospoolanatomy.tex}
+\pagebreak
+
+\section{Repository Configuration Directory}
+The authoritative configuration of a \cvmfs\ repository is located in \texttt{/etc/cvmfs/repositories.d} and should only be writable by the administrator.
+Furthermore the repository's keychain is located in \texttt{/etc/cvmfs/keys} and follows the naming convention \texttt{<fqrn>.crt} for the certificate, \texttt{<fqrn>.key} for the repository's private key and \texttt{<fqrn>.pub} for the public key.
+All of those files can be symlinked somewhere else if necessary.
+
+\LTXtable{\textwidth}{figures/tabrepoconfiganatomy.tex}
+\pagebreak

--- a/apx-serverinfra.tex
+++ b/apx-serverinfra.tex
@@ -1,0 +1,4 @@
+\chapter{\cvmfs\ Server Infrastructure}
+\label{apx:serverinfrastructure}
+
+tbd

--- a/cpt-repo.tex
+++ b/cpt-repo.tex
@@ -129,6 +129,7 @@ Please note, that Scientific Linux 6 \emph{does not} ship with an \aufs\ enabled
 \label{sct:repoanatomy}
 There are a number of possible customisations in the \cvmfs\ server installation.
 The following table provides an overview of important configuration files and intrinsical paths together with some customisation hints.
+For an exhaustive description of the \cvmfs\ server infrastructure please consult Appendix~\ref{apx:serverinfrastructure}.
 \LTXtable{\textwidth}{figures/tabserveranatomy.tex}
 
 

--- a/cvmfstech.tex
+++ b/cvmfstech.tex
@@ -132,6 +132,7 @@
 %\include{apx-releasemgr}
 \include{apx-rpms}
 \include{apx-parameters}
+\include{apx-serverinfra}
 
 \pagestyle{plain}
 \bibliographystyle{alpha}

--- a/figures/tablocalstorageanatomy.tex
+++ b/figures/tablocalstorageanatomy.tex
@@ -1,0 +1,37 @@
+\begin{longtable}{lX}
+	\toprule
+	{\bf\centering File Path} & {\bf\centering Description} \\
+	\midrule
+
+	\texttt{/srv/cvmfs} & \textbf{Central repository storage location} \newline
+	Can be mounted or symlinked to another location \emph{before} creating the first repository. \\
+	\addlinespace
+
+	\texttt{/srv/cvmfs/<fqrn>} & \textbf{Storage location of a specific repository} \newline
+	Can be symlinked to another location \emph{before} creating the repository \texttt{<fqrn>}. This location needs to be both writable by the repository owner and accessible through an HTTP server. \\
+	\addlinespace
+
+	\texttt{/srv/cvmfs/<fqrn>/.cvmfspublished} & \textbf{Manifest file of the repository} \newline
+	The manifest provides the entry point into the repository. It is the only file that needs to be signed by the repository's private key. \\
+	\addlinespace
+
+	\texttt{/srv/cvmfs/<fqrn>/.cvmfswhitelist} & \textbf{List of trusted repository certificates} \newline
+	Contains a list of certificate fingerprints that should be allowed to sign a repository manifest (see .cvmfspublished). The whitelist needs to be signed by a globally trusted private key.\\
+	\addlinespace
+
+	\texttt{/srv/cvmfs/<fqrn>/data} & \textbf{CAS location of the repository} \newline
+    Data storage of the repository. Contains catalogs, files, file chunks, certificates and history databases in a content addressable file format. This directory and all its contents need to be writable by the repository owner.\\
+	\addlinespace
+
+	\texttt{/srv/cvmfs/<fqrn>/data/00..ff} & \textbf{Second CAS level directories} \newline
+	Splits the flat CAS namespace into multiple directories. First two digits of the file content hash defines the directory the remainder is used as file name inside the corresponding directory.\\
+	\addlinespace
+
+	\texttt{/srv/cvmfs/<fqrn>/data/txn} & \textbf{CAS transaction directory} \newline
+	Stores partial files during creation. Once writing has completed, the file is committed into the CAS using an atomic rename operation. \\
+	\addlinespace
+
+	\bottomrule
+	\caption{Constituents of a local \cvmfs\ data backend storage location.}
+	\label{tbl:localbackendanatomy}
+\end{longtable}

--- a/figures/tabparameters.tex
+++ b/figures/tabparameters.tex
@@ -49,6 +49,8 @@
 		\tt CVMFS\_USER					& Sets the \texttt{gid} and \texttt{uid} mount options. Don't touch or overwrite.\\
 		\tt CVMFS\_USYSLOG				& All messages that normally are logged to syslog are re-directed to the given file.  This file can grow up to \SI{500}{\kilo\byte} and there is one step of log rotation.  Required for $\mu$CernVM.\\
 		\bottomrule
+
+		\label{tab:clientparameters}
 	\end{longtable}
 %\end{longtable}
 %\end{center}

--- a/figures/tabrepoconfiganatomy.tex
+++ b/figures/tabrepoconfiganatomy.tex
@@ -1,0 +1,29 @@
+\begin{longtable}{lX}
+	\toprule
+	{\bf\centering File Path} & {\bf\centering Description} \\
+	\midrule
+
+	\texttt{/etc/cvmfs/repositories.d} & \textbf{\cvmfs\ server config directory} \newline
+	This contains the configuration directories for individual \cvmfs\ repositories. Note that this path is shortened using \texttt{/.../repos.d/} in the rest of this table. \\
+	\addlinespace
+
+	\texttt{/.../repos.d/<fqrn>} & \textbf{Config directory for specific repo} \newline
+	This contains the configuration files for one specific \cvmfs\ repository server. \\
+	\addlinespace
+
+	\texttt{/.../repos.d/<fqrn>/server.conf} & \textbf{Server configuration file} \newline
+	Authoriative configuration file for the \cvmfs\ server tools. This file should only contain configuration variables found in Table~\ref{tab:serverparameters} as it controls the behaviour of the \cvmfs\ server operations like publishing, pulling and so forth. \\
+	\addlinespace
+
+	\texttt{/.../repos.d/<fqrn>/client.conf} & \textbf{Client configuration file} \newline
+	Authoriative configuration file for the \cvmfs\ client used to mount the latest revision of a Stratum~0 release manager machine. This file should only contain configuration variables as listed in Table~\ref{tab:clientparameters}. This file must not exist for Stratum~1 repositories. \\
+	\addlinespace
+
+	\texttt{/.../repos.d/<fqrn>/replica.conf} & \textbf{Replication configuration file} \newline
+	Contains configuration variables for Stratum~1 specific repositories. This file must not exist for Stratum~0 repositories. \\
+	\addlinespace
+
+	\bottomrule
+	\caption{Constituents of the repository spool area.}
+	\label{tbl:repoconfiganatomy}
+\end{longtable}

--- a/figures/tabrepoconfiganatomy.tex
+++ b/figures/tabrepoconfiganatomy.tex
@@ -24,6 +24,6 @@
 	\addlinespace
 
 	\bottomrule
-	\caption{Constituents of the repository spool area.}
+	\caption{\cvmfs\ server repository configuration file locations.}
 	\label{tbl:repoconfiganatomy}
 \end{longtable}

--- a/figures/tabrepospoolanatomy.tex
+++ b/figures/tabrepospoolanatomy.tex
@@ -1,0 +1,37 @@
+\begin{longtable}{lX}
+	\toprule
+	{\bf\centering File Path} & {\bf\centering Description} \\
+	\midrule
+
+	\texttt{/var/spool/cvmfs} & \textbf{\cvmfs\ server spool area} \newline
+	Contains administrative and scratch space for \cvmfs\ repositories. This directory should only contain directories corresponding to individual \cvmfs\ repositories. \\
+	\addlinespace
+
+	\texttt{/var/spool/cvmfs/<fqrn>} & \textbf{Individual repository spool area} \newline
+	Contains the spool area of an individual repository and might temporarily contain large data volumes during massive repository updates. This location can be mounted or symlinked to other locations. Furthermore it must be writable by the repository owner. \\
+	\addlinespace
+
+	\texttt{/var/spool/cvmfs/<fqrn>/cache} & \textbf{\cvmfs\ client cache directory} \newline
+	Contains the cache of the \cvmfs\ client mounting the r/o branch (i.e. \texttt{/var/spool/cvmfs/<fqrn>/rdonly}) of the \aufs\ mount point located at \texttt{/cvmfs/<fqrn>}. The content of this directory is fully managed by the \cvmfs\ client and hence must be configured as a \cvmfs\ cache and writable for the repository owner. \\
+	\addlinespace
+
+	\texttt{/var/spool/cvmfs/<fqrn>/rdonly} & \textbf{\cvmfs\ client mount point} \newline
+	Serves as the mount point of the \cvmfs\ client exposing the latest published state of the \cvmfs\ repository. It needs to be owned by the repository owner and should be empty if \cvmfs\ is not mounted to it. \\
+	\addlinespace
+
+	\texttt{/var/spool/cvmfs/<fqrn>/scratch} & \textbf{Writable \aufs\ scratch area} \newline
+	All file system changes applied to \texttt{/cvmfs/<fqrn>} during a transaction will be stored in this directory. Hence, it potentially needs to accommodate a large data volume during massive repository updates. Furthermore it needs to be writable by the repository owner. \\
+	\addlinespace
+
+	\texttt{/var/spool/cvmfs/<fqrn>/tmp} & \textbf{Temporary scratch location} \newline
+	Some \cvmfs\ server operations like publishing store temporary data files here, hence it needs to be writable by the repository owner. If the repository is idle this directory should be empty.  \\
+	\addlinespace
+
+	\texttt{/var/spool/cvmfs/<fqrn>/client.config} & \textbf{\cvmfs\ client configuration} \newline
+	This contains client configuration variables for the \cvmfs\ client mounted to \texttt{/var/spool/cvmfs/<fqrn>/rdonly}. Most notibly it needs to contain \texttt{CVMFS\_ROOT\_HASH} configured to the latest revision published in the corresponding repository. This file needs to be writable by the repository owner. \\
+	\addlinespace
+
+	\bottomrule
+	\caption{Constituents of the repository spool area.}
+	\label{tbl:repospoolanatomy}
+\end{longtable}

--- a/figures/tabserveranatomy.tex
+++ b/figures/tabserveranatomy.tex
@@ -13,7 +13,7 @@
 	Can be mounted or symlinked to another location \emph{before} creating the first repository. \\
 	\addlinespace
 
-	\texttt{/srv/cvmfs/<fqrn>} & \textbf{Storage location of a specfic repository} \newline
+	\texttt{/srv/cvmfs/<fqrn>} & \textbf{Storage location of a specific repository} \newline
 	Can be symlinked to another location \emph{before} creating the repository \texttt{<fqrn>}. \\
 	\addlinespace
 

--- a/figures/tabserverparameters.tex
+++ b/figures/tabserverparameters.tex
@@ -31,6 +31,8 @@
 		\tt CVMFS\_AUTO\_GC					& Enables the automatic garbage collection on \texttt{publish} and \texttt{snapshot}\\
 		\tt CVMFS\_AUTO\_GC\_TIMESPAN		& Date-threshold for automatic garbage collection \newline (For example: \texttt{3 days ago}, \texttt{1 week ago}, ...)\\
 		\bottomrule
+
+		\label{tab:serverparameters}
 	\end{longtable}
 %\end{longtable}
 %\end{center}


### PR DESCRIPTION
This is a (admittedly rough) description of the entire CernVM-FS Server infrastructure and all of its constituents. I believe it serves more as an overview but I hope it will help @traylenator to setup a server without using `cvmfs_server`.