### PR TITLE
FIX: 2.1.20 References

### DIFF
--- a/apx-parameters.rst
+++ b/apx-parameters.rst
@@ -101,12 +101,3 @@ CVMFS_GARBAGE_COLLECTION            Enables repository garbage collection |br| (
 CVMFS_AUTO_GC                       Enables the automatic garbage collection on *publish* and *snapshot*
 CVMFS_AUTO_GC_TIMESPAN              Date-threshold for automatic garbage collection |br| (For example: `3 days ago`, `1 week ago`, ...)
 =================================== ============================================================================================================================================================
-
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   </div>

--- a/apx-references.rst
+++ b/apx-references.rst
@@ -76,3 +76,6 @@ References
 .. [Tolia03] Tolia, N. et al. 2003. Opportunistic use of content addressable
    storage for distributed file systems. *Proc. of the uSENIX annual
    technical conference* (2003).
+
+.. [Mockapetris87] Mockapetris, P. 1987. *Domain names - implementation and
+   specification*. Technical Report #1035. Internet Engineering Task Force.

--- a/apx-references.rst
+++ b/apx-references.rst
@@ -21,3 +21,31 @@ References
 
 .. [Shepler03] Shepler, S. et al. 2003. *Network File System (NFS) version 4
    Protocol*. Technical Report #3530. Internet Engineering Task Force.
+
+.. [Jones01] 3rd, D.E. and Jones, P. 2001. *US Secure Hash Algorithm 1 (SHA1)*.
+   Technical Report #3174. Internet Engineering Task Force.
+
+.. [Dobbertin96] Dobbertin, H. et al. 1996. RIPEMD-160: A strengthened version of
+   RIPEMD. Springer. 71–82.
+
+.. [Bertoni09] Bertoni, G., Daemen, J., Peeters, M. and Van Assche, G., 2009.
+   Keccak sponge function family main document.
+   Submission to NIST (Round 2), 3, p.30.
+
+.. [Rivest92] Rivest, R. 1992. *The MD5 Message-Digest Algorithm*. Technical
+   Report #1321. Internet Engineering Task Force.
+
+.. [Turner11] Turner, S. and Chen, L. 2011. *Updated Security Considerations for
+   the MD5 Message-Digest and the HMAC-MD5 Algorithms*. Technical Report
+   #6151. Internet Engineering Task Force.
+
+.. [Deutsch96] Deutsch, P. and Gailly, J.-L. 1996. *ZLIB Compressed Data Format
+   Specification version 3.3*. Technical Report #1950. Internet Engineering
+   Task Force.
+
+.. [Allen10] Allen, G. and Owens, M. 2010. *The definitive guide to SQLite*.
+   Apress.
+
+.. [Wright04] Wright, C.P. et al. 2004. *Versatility and unix semantics in a
+   fan-out unification file system*. Technical Report #FSL-04-01b.
+   Stony Brook University.

--- a/apx-references.rst
+++ b/apx-references.rst
@@ -79,3 +79,7 @@ References
 
 .. [Mockapetris87] Mockapetris, P. 1987. *Domain names - implementation and
    specification*. Technical Report #1035. Internet Engineering Task Force.
+
+.. [Dykstra10] Dykstra, D. and Lueking, L. 2010. Greatly improved cache update
+   times for conditions data with frontier/Squid. *Journal of Physics:
+   Conference Series*. 219, (2010).

--- a/apx-references.rst
+++ b/apx-references.rst
@@ -1,0 +1,23 @@
+References
+==========
+
+.. [Blumenfeld08] Blumenfeld, B. et al. 2008. CMS conditions data access using
+   FroNTier. *Journal of Physics: Conference Series*. 119, (2008).
+
+.. [Callaghan95] Callaghan, B. et al. 1995. *NFS Version 3 Protocol Specification*.
+   Technical Report #1813. Internet Engineering Task Force.
+
+.. [Gauthier99] Gauthier, P. et al. 1999. *Web proxy auto-discovery protocol*. IETF
+   Secretariat.
+
+.. [Guerrero99] Guerrero, D. 1999. Caching the web, part 2. *Linux Journal*. 58
+   (Feburary 1999).
+
+.. [Panagiotou06] Panagiotou, K. and Souza, A. 2006. On adequate performance measures
+   for paging. *Annual ACM Symposium on Theory Of Computing*. 38, (2006), 487–496.
+
+.. [Schubert08] Schubert, M. et al. 2008. *Nagios 3 enterprise network monitoring*.
+   Syngress.
+
+.. [Shepler03] Shepler, S. et al. 2003. *Network File System (NFS) version 4
+   Protocol*. Technical Report #3530. Internet Engineering Task Force.

--- a/apx-references.rst
+++ b/apx-references.rst
@@ -49,3 +49,30 @@ References
 .. [Wright04] Wright, C.P. et al. 2004. *Versatility and unix semantics in a
    fan-out unification file system*. Technical Report #FSL-04-01b.
    Stony Brook University.
+
+.. [BernersLee96] Berners-Lee, T. et al. 1996. *Hypertext Transfer Protocol – HTTP/1.0*.
+   Technical Report #1945. Internet Engineering Task Force.
+
+.. [Fielding99] Fielding, R. et al. 1999. *Hypertext Transfer Protocol – HTTP/1.1*.
+   Technical Report #2616. Internet Engineering Task Force.
+
+.. [Compostella10] Compostella, G. et al. 2010. CDF software distribution on the Grid
+   using Parrot. *Journal of Physics: Conference Series*. 219, (2010).
+
+.. [Thain05] Thain, D. and Livny, M. 2005. Parrot: an application environment for
+   data-intensive computing. *Scalable Computing: Practice and Experience*.
+   6, 3 (18 2005), 9.
+
+.. [Suzaki06] Suzaki, K. et al. 2006. HTTP-FUSE Xenoppix. *Proc. of the 2006 linux
+   symposium* (2006), 379–392.
+
+.. [Freedman03] Freedman, M.J. and Mazières, D. 2003. Sloppy hashing and
+   self-organizing clusters. M.F. Kaashoek and I. Stoica, eds. Springer. 45–55.
+
+.. [Nygren10] Nygren, E. et al. 2010. The Akamai network: A platform for
+   high-performance internet applications. *ACM SIGOPS Operating Systems
+   Review*. 44, 3 (2010), 2–19.
+
+.. [Tolia03] Tolia, N. et al. 2003. Opportunistic use of content addressable
+   storage for distributed file systems. *Proc. of the uSENIX annual
+   technical conference* (2003).

--- a/apx-rpms.rst
+++ b/apx-rpms.rst
@@ -24,7 +24,7 @@ The CernVM-FS software is available in form of several RPM packages:
 
 **cvmfs-devel**
     Contains the ``libcvmfs.a`` static library and the ``libcvmfs.h``
-    header file for use of CernVM-FS with Parrot[1].
+    header file for use of CernVM-FS with Parrot [Thain05]_.
 
 **cvmfs-auto-setup**
     Only available through yum. This is a wrapper for
@@ -45,23 +45,3 @@ The CernVM-FS software is available in form of several RPM packages:
 
 **cvmfs-unittests**
     Contains the ``cvmfs_unittests`` binary. Only required for testing.
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   <div id="ref-parrot05">
-
-[1] Thain, D. and Livny, M. 2005. Parrot: an application environment for
-data-intensive computing. *Scalable Computing: Practice and Experience*.
-6, 3 (18 2005), 9.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>

--- a/apx-serverinfra.rst
+++ b/apx-serverinfra.rst
@@ -18,7 +18,7 @@ Prerequisites
 A CernVM-FS server installation depends on the following environment
 setup and tools to be in place:
 
--  aufs support in the kernel (see Section [sct:customkernelinstall])
+-  aufs support in the kernel (see Section :ref:`sct_customkernelinstall`)
 
 -  Backend storage location available through HTTP
 
@@ -213,11 +213,3 @@ CernVM-FS uses the following entries for these mount points:
 
     aufs_<fqrn> /cvmfs/<fqrn> aufs br=/var/spool/cvmfs/<fqrn>/scratch=rw: \
     /var/spool/cvmfs/<fqrn>/rdonly=rr,udba=none,ro 0 0
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   </div>

--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -191,15 +191,15 @@ Network Settings
 
 CernVM-FS uses HTTP for the data transfer. Repository data can be
 replicated to multiple web servers and cached by standard web proxies
-such as Squid [5]. In a typical setup, repositories are replicated to a
-handful of web servers in different locations. These replicas form the
+such as Squid [Guerrero99]_. In a typical setup, repositories are replicated to
+a handful of web servers in different locations. These replicas form the
 CernVM-FS Stratum 1 service, whereas the replication source server is
 the CernVM-FS Stratum 0 server. In every cluster of client machines,
 there should be two or more web proxy servers that CernVM-FS can use
 (see :ref:`cpt_squid`). These site-local web proxies reduce the
 network latency for the CernVM-FS clients and they reduce the load for
 the Stratum 1 service. CernVM-FS supports WPAD/PAC proxy auto
-configuration [4], choosing a random proxy for load-balancing, and
+configuration [Gauthier99]_, choosing a random proxy for load-balancing, and
 automatic fail-over to other hosts and proxies in case of network
 errors. Roaming clients can connect directly to the Stratum 1 service.
 
@@ -251,7 +251,7 @@ proxies.
 
 The chain of proxy groups is specified by a string of semicolon
 separated entries, each group is a list of pipe separated
-hostnames [2]_. Multiple IP addresses behind a single proxy host name
+hostnames [#]_. Multiple IP addresses behind a single proxy host name
 (DNS *round-robin* entry) are automatically transformed into a
 load-balanced group. The ``DIRECT`` keyword for a hostname avoids using
 proxies. Note that the ``CVMFS_HTTP_PROXY`` parameter is necessary in
@@ -278,7 +278,7 @@ for PAC files in the order given by the semicolon separated URLs in the
 ``CVMFS_PAC_URLS`` environment variable. This variable defaults to
 http://wpad/wpad.dat. The ``auto`` keyword used as a URL in
 ``CVMFS_PAC_URLS`` is resolved to http://wpad/wpad.dat, too, in order to
-be compatible with Frontier [1].
+be compatible with Frontier [Blumenfeld08]_.
 
 Fallback Proxy List
 ~~~~~~~~~~~~~~~~~~~
@@ -343,7 +343,8 @@ Downloaded files will be stored in a local cache directory. The
 CernVM-FS cache has a soft quota; as a safety margin, the partition
 hosting the cache should provide more space than the soft quota limit.
 Once the quota limit is reached, CernVM-FS will automatically remove
-files from the cache according to the least recently used policy [6].
+files from the cache according to the least recently used policy
+[Panagiotou06]_.
 Removal of files is performed bunch-wise until half of the maximum cache
 size has been freed. The quota limit can be set in Megabytes by
 ``CVMFS_QUOTA_LIMIT``. For typical repositories, a few Gigabytes make a
@@ -418,10 +419,10 @@ NFS Server Mode
 ---------------
 
 In case there is no local hard disk space available on a cluster of
-worker nodes, a single CernVM-FS client can be exported via nfs [2, 8]
-to these worker nodes. This mode of deployment will inevitably introduce
-a performance bottleneck and a single point of failure and should be
-only used if necessary.
+worker nodes, a single CernVM-FS client can be exported via
+nfs [Callaghan95]_ [Shepler03]_ to these worker nodes.This mode of deployment
+will inevitably introduce a performance bottleneck and a single point of
+failure and should be only used if necessary.
 
 NSF export requires Linux kernel >= 2.6.27 on the NFS server. For
 instance, exporting works for Scientific Linux 6 but not for Scientific
@@ -460,13 +461,14 @@ NFS daemons is set by the ``RPCNFSDCOUNT`` parameter in
 /etc/sysconfig/nfs.
 
 The performance will benefit from large RAM on the NFS server
-(:math:`\geq\SI{16}{\giga\byte}`) and CernVM-FS caches hosted on an SSD
+(:math:`\geq` 16GB) and CernVM-FS caches hosted on an SSD
 hard drive.
 
 Shared NFS Maps (HA-NFS)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-As an alternative to the existing, leveldb [3] managed NFS maps, the NFS
+As an alternative to the existing, `leveldb
+<https://github.com/google/leveldb>`_ managed NFS maps, the NFS
 maps can optionally be managed out of the CernVM-FS cache directory by
 SQLite. This allows the NFS maps to be placed on shared storage and
 accessed by multiple CernVM-FS NFS export nodes simultaneously for
@@ -648,8 +650,9 @@ toolchain, information about the overall number of file system entries
 in the repository as well as the number of entries covered by currently
 loaded meta-data can be gathered by ``df -i``.
 
-For the Nagios\  [3]_ [7] monitoring system, a checker plugin is
-available under http://cernvm.cern.ch/portal/filesystem/downloads.
+For the `Nagios monitoring system <http://www.nagios.org>`_ [Schubert08]_, a
+checker plugin is available `on our website
+<http://cernvm.cern.ch/portal/filesystem/downloads>`_.
 
 Debug Logs
 ----------
@@ -665,109 +668,9 @@ can be started in debug mode. In the debug mode, CernVM-FS will log with high
 verbosity which makes the debug mode unsuitable for production use. In order
 to turn on the debug mode, set ``CVMFS_DEBUGFILE=/tmp/cvmfs.log``.
 
-.. raw:: html
 
-   <div id="refs" class="references">
+.. rubric:: Footnotes
 
-.. raw:: html
-
-   <div id="ref-frontier08">
-
-[1] Blumenfeld, B. et al. 2008. CMS conditions data access using
-FroNTier. *Journal of Physics: Conference Series*. 119, (2008).
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-rfc1813">
-
-[2] Callaghan, B. et al. 1995. *NFS Version 3 Protocol Specification*.
-Technical Report #1813. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-leveldb">
-
-[3] Dean, J. and Ghemawat, S. Leveldb.
-http://code.google.com/p/leveldb/.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-wpad99">
-
-[4] Gauthier, P. et al. 1999. *Web proxy auto-discovery protocol*. IETF
-Secretariat.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-squid99">
-
-[5] Guerrero, D. 1999. Caching the web, part 2. *Linux Journal*. 58
-(Feburary 1999).
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-lru06">
-
-[6] Panagiotou, K. and Souza, A. 2006. On adequate performance measures
-for paging. *Annual ACM Symposium on Theory Of Computing*. 38, (2006),
-487–496.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-nagios08">
-
-[7] Schubert, M. et al. 2008. *Nagios 3 enterprise network monitoring*.
-Syngress.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-rfc3530">
-
-[8] Shepler, S. et al. 2003. *Network File System (NFS) version 4
-Protocol*. Technical Report #3530. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>
-
-.. [1]
-   http://ccl.cse.nd.edu/software/parrot
-
-.. [2]
+.. [#]
    The usual proxy notation rules apply, like
    ``http://proxy1:8080|http://proxy2:8080;DIRECT``
-
-.. [3]
-   http://www.nagios.org

--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -26,20 +26,20 @@ its metadata. The table layout is shown in the table below:
 .. _tab_catalog:
 
 ====================== ================
-**Field**               **Type**       
+**Field**               **Type**
 ====================== ================
-Path MD5                128Bit Integer 
-Parent Path MD5         128Bit Integer 
-Hardlinks               Integer        
-SHA1 Content Hash       160Bit Integer 
-Size                    Integer        
-Mode                    Integer        
-Last Modified           Timestamp      
-Flags                   Integer        
-Name                    String         
-Symlink                 String         
-uid                     Integer        
-gid                     Integer        
+Path MD5                128Bit Integer
+Parent Path MD5         128Bit Integer
+Hardlinks               Integer
+SHA1 Content Hash       160Bit Integer
+Size                    Integer
+Mode                    Integer
+Last Modified           Timestamp
+Flags                   Integer
+Name                    String
+Symlink                 String
+uid                     Integer
+gid                     Integer
 ====================== ================
 
 In order to save space we do not store absolute paths. Instead we

--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -19,9 +19,9 @@ File Catalog
 ------------
 
 A CernVM-FS repository is defined by its *file catalog*. The file
-catalog is an SQLite\  [1]_ database [2] having a single table that
-lists files and directories together with its metadata. The table layout
-is shown in the table below:
+catalog is an `SQLite database <https://www.sqlite.org>`_ [Allen10]_
+having a single table that lists files and directories together with
+its metadata. The table layout is shown in the table below:
 
 .. _tab_catalog:
 
@@ -42,19 +42,20 @@ uid                     Integer
 gid                     Integer        
 ====================== ================
 
-In order to save space we do not store absolute paths. Instead we store
-MD5 [8, 10] hash values of the absolute path names. Symbolic links are
-kept in the catalog. Symbolic links may contain environment variables in
-the form ``$(VAR_NAME)`` or ``$(VAR_NAME:-/default/path)`` that will be
-dynamically resolved by CernVM-FS on access. Hardlinks are emulated by
-CernVM-FS. The hardlink count is stored in the lower 32bit of the
-hardlinks field, a *hardlink group* is stored in the higher 32 bit. If
-the hardlink group is greater than zero, all files with the same
-hardlink group will get the same inode issued by the CernVM-FS Fuse
-client. The emulated hardlinks work within the same directory, only. The
-cryptographic content hash refers to the zlib-compressed [5] version of
-the file. Flags indicate the type of an directory entry (see
-table :ref:`below <tab_dirent_flags>`).
+In order to save space we do not store absolute paths. Instead we
+store MD5 [Rivest92]_, [Turner11]_ hash values of the absolute path
+names. Symbolic links are kept in the catalog. Symbolic links may
+contain environment variables in the form ``$(VAR_NAME)`` or
+``$(VAR_NAME:-/default/path)`` that will be dynamically resolved by
+CernVM-FS on access. Hardlinks are emulated by CernVM-FS. The hardlink
+count is stored in the lower 32bit of the hardlinks field, a *hardlink
+group* is stored in the higher 32 bit. If the hardlink group is
+greater than zero, all files with the same hardlink group will get the
+same inode issued by the CernVM-FS Fuse client. The emulated hardlinks
+work within the same directory, only. The cryptographic content hash
+refers to the zlib-compressed [Deutsch96]_ version of the file. Flags
+indicate the type of an directory entry (see table :ref:`below
+<tab_dirent_flags>`).
 
 .. _tab_dirent_flags:
 
@@ -81,19 +82,20 @@ catalog and kernel caching is turned back on.
 Content Hashes
 ~~~~~~~~~~~~~~
 
-CernVM-FS can use SHA-1 [1] or RIPEMD-160 [6] as cryptographic hash
-function. The hash function can be changed on the Stratum 0 during the
-lifetime of repositories. On a change, new and updated files will use
-the new cryptographic hash while existing files remain unchanged. This
-is transparent to the clients since the hash function is stored in the
-flags field of file catalogs for each and every file. The default hash
-function is SHA-1. New software versions might introduce support for
-further cryptographic hash functions.
+CernVM-FS can use SHA-1 [Jones01]_, RIPEMD-160 [Dobbertin96]_ and
+SHAKE-128 [Bertoni09]_ as cryptographic hash function. The hash function
+can be changed on the Stratum 0 during the lifetime of repositories.
+On a change, new and updated files will use the new cryptographic hash
+while existing files remain unchanged. This is transparent to the clients
+since the hash function is stored in the flags field of file catalogs for
+each and every file. The default hash function is SHA-1.
+New software versions might introduce support for further cryptographic
+hash functions.
 
 Nested Catalogs
 ~~~~~~~~~~~~~~~
 
-In order to keep catalog sizes reasonable [2]_, repository subtrees may be cut
+In order to keep catalog sizes reasonable [#]_, repository subtrees may be cut
 and stored as separate *nested catalogs*. There is no limit on the level of
 nesting. A reasonable approach is to store separate software versions as
 separate nested catalogs. The figure :ref:`below <fig_nested>` shows the
@@ -269,7 +271,8 @@ blacklist /etc/cvmfs/blacklist. The blacklisted fingerprints have to be
 in the same format than the fingerprints on the white-list. The
 blacklist has precedence over the white-list.
 
-As crypto engine, CernVM-FS uses libcrypto from the OpenSSL project [9].
+As crypto engine, CernVM-FS uses libcrypto from the `OpenSSL project
+<http://www.openssl.org/docs/crypto/crypto.html>`_.
 
 Use of HTTP
 -----------
@@ -277,7 +280,7 @@ Use of HTTP
 The particular way of using the HTTP protocol has significant impact on
 the performance and usability of CernVM-FS. If possible, CernVM-FS tries
 to benefit from the HTTP/1.1 features keep-alive and cache-control.
-Internally, CernVM-FS uses the libcurl library [3].
+Internally, CernVM-FS uses the `libcurl library <http://curl.haxx.se/libcurl>`_.
 
 The HTTP behaviour affects a system with cold caches only. As soon as
 all necessary files are cached, there is only network traffic when a
@@ -407,10 +410,10 @@ they are renamed into their content-addressable names atomically by
 
 The hard disk cache is managed, CernVM-FS maintains cache size
 restrictions and replaces files according to the least recently used
-(LRU) strategy [7]. In order to keep track of files sizes and relative
-file access times, CernVM-FS sets up another SQLite database in the
-cache directory, the *cache catalog*. The cache catalog contains a
-single table; its structure is shown here:
+(LRU) strategy [Panagiotou06]_. In order to keep track of files sizes
+and relative file access times, CernVM-FS sets up another SQLite
+database in the cache directory, the *cache catalog*. The cache
+catalog contains a single table; its structure is shown here:
 
 ================================= =========================
 **Field**                         **Type**
@@ -472,19 +475,20 @@ NFS Maps
 --------
 
 In normal mode, CernVM-FS issues inodes based on the row number of an
-entry in the file catalog. When exported via NFS, this scheme can result
-in inconsistencies because CernVM-FS does not control the cache lifetime
-of NFS clients. A once issued inode can be asked for anytime later by a
-client. To be able to reply to such client queries even after reloading
-catalogs or remounts of CernVM-FS, the CernVM-FS *NFS maps* implement a
-persistent store of the path names :math:`\mapsto` inode mappings.
-Storing them on hard disk allows for control of the CernVM-FS memory
-consumption (currently :math:`\approx` 45 MB extra) and
-ensures consistency between remounts of CernVM-FS. The performance
-penalty for doing so is small. CernVM-FS uses Google’s leveldb\ [4], a
-fast, local key value store. Reads and writes are only performed when
-meta-data are looked up in SQLite, in which case the SQLite query
-supposedly dominates the running time.
+entry in the file catalog. When exported via NFS, this scheme can
+result in inconsistencies because CernVM-FS does not control the cache
+lifetime of NFS clients. A once issued inode can be asked for anytime
+later by a client. To be able to reply to such client queries even
+after reloading catalogs or remounts of CernVM-FS, the CernVM-FS *NFS
+maps* implement a persistent store of the path names :math:`\mapsto`
+inode mappings. Storing them on hard disk allows for control of the
+CernVM-FS memory consumption (currently :math:`\approx` 45 MB extra)
+and ensures consistency between remounts of CernVM-FS. The performance
+penalty for doing so is small. CernVM-FS uses `Google’s leveldb
+<https://github.com/google/leveldb>`, a fast, local key value store.
+Reads and writes are only performed when meta-data are looked up in
+SQLite, in which case the SQLite query supposedly dominates the
+running time.
 
 A drawback of the NFS maps is that there is no easy way to account for
 them by the cache quota. They sum up to some 150-200 Bytes per path name
@@ -704,12 +708,12 @@ changes are in fact written to the read-write branch.
 
 Preserving POSIX semantics in union file systems is non-trivial; the
 first fully functional implementation has been presented by Wright et
-al. [11]. By now, union file systems are well established for “Live CD”
-builders, which use a RAM disk overlay on top of the read-only system
-partition in order to provide the illusion of a fully read-writable
-system. CernVM-FS uses the AUFS union file system. Another union file
-system with similar semantics can be plugged in if necessary. OverlayFS
-is supported as an experimental alternative.
+al. [Wright04]_. By now, union file systems are well established for
+“Live CD” builders, which use a RAM disk overlay on top of the read-
+only system partition in order to provide the illusion of a fully
+read-writable system. CernVM-FS uses the AUFS union file system.
+Another union file system with similar semantics can be plugged in if
+necessary. OverlayFS is supported as an experimental alternative.
 
 Union file systems can be used to track changes on CernVM-FS repositories
 (Figure :ref:`below <fig_overlay>`). In this case, the read-only file system
@@ -735,141 +739,8 @@ scratch area and, once published, are re-mounted as repository revision
 :math:`r+1`. In this way, CernVM-FS provides snapshots. In case of
 errors, one can safely resume from a previously committed revision.
 
-.. raw:: html
+.. rubric:: Footnotes
 
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   <div id="ref-rfc3174">
-
-[1] 3rd, D.E. and Jones, P. 2001. *US Secure Hash Algorithm 1 (SHA1)*.
-Technical Report #3174. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-sqlite10">
-
-[2] Allen, G. and Owens, M. 2010. *The definitive guide to SQLite*.
-Apress.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-libcurl">
-
-[3] Daniel Stenberg et al. libcurl. http://curl.haxx.se/libcurl.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-leveldb">
-
-[4] Dean, J. and Ghemawat, S. Leveldb.
-http://code.google.com/p/leveldb/.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-rfc1950">
-
-[5] Deutsch, P. and Gailly, J.-L. 1996. *ZLIB Compressed Data Format
-Specification version 3.3*. Technical Report #1950. Internet Engineering
-Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-ripemd160">
-
-[6] Dobbertin, H. et al. 1996. RIPEMD-160: A strengthened version of
-RIPEMD. Springer. 71–82.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-lru06">
-
-[7] Panagiotou, K. and Souza, A. 2006. On adequate performance measures
-for paging. *Annual ACM Symposium on Theory Of Computing*. 38, (2006),
-487–496.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-rfc1321">
-
-[8] Rivest, R. 1992. *The MD5 Message-Digest Algorithm*. Technical
-Report #1321. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-openssl">
-
-[9] The OpenSSL Software Foundation OpenSSL.
-http://www.openssl.org/docs/crypto/crypto.html.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-rfc6151">
-
-[10] Turner, S. and Chen, L. 2011. *Updated Security Considerations for
-the MD5 Message-Digest and the HMAC-MD5 Algorithms*. Technical Report
-#6151. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-unionfs04">
-
-[11] Wright, C.P. et al. 2004. *Versatility and unix semantics in a
-fan-out unification file system*. Technical Report #FSL-04-01b. Stony
-Brook University.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>
-
-.. [1]
-   https://www.sqlite.org
-
-.. [2]
+.. [#]
    As a rule of thumb, file catalogs up to (compressed) are reasonably
    small.

--- a/cpt-overview.rst
+++ b/cpt-overview.rst
@@ -2,16 +2,17 @@ Overview
 ========
 
 The CernVM File System (CernVM-FS) is a read-only file system designed
-to deliver scientific software onto virtual machines and physical worker
-nodes in a fast, scalable, and reliable way. Files and file metadata are
-downloaded on demand and aggressively cached. For the distribution of
-files, CernVM-FS uses a standard HTTP [1, 3] transport, which allows
-exploitation of a variety of web caches, including commercial content
-delivery networks. CernVM-FS ensures data authenticity and integrity
-over these possibly untrusted caches and connections. The
-CernVM-FS software comprises client-side software to mount
-“CernVM-FS repositories” (similar to AFS volumes) as well as a
-server-side toolkit to create such distributable CernVM-FS repositories.
+to deliver scientific software onto virtual machines and physical
+worker nodes in a fast, scalable, and reliable way. Files and file
+metadata are downloaded on demand and aggressively cached. For the
+distribution of files, CernVM-FS uses a standard HTTP [BernersLee96]_
+[Fielding99]_ transport, which allows exploitation of a variety of web
+caches, including commercial content delivery networks. CernVM-FS
+ensures data authenticity and integrity over these possibly untrusted
+caches and connections. The CernVM-FS software comprises client-side
+software to mount “CernVM-FS repositories” (similar to AFS volumes) as
+well as a server-side toolkit to create such distributable CernVM-FS
+repositories.
 
 .. figure:: _static/concept-generic.svg
    :alt: General overview over CernVM-File System's Architecture
@@ -21,15 +22,16 @@ server-side toolkit to create such distributable CernVM-FS repositories.
    (such as an HEP experiment framework) are hosted as a
    CernVM-FS repository on a web server.
 
-The first implementation of CernVM-FS was based on grow-fs [2, 8], which
-was originally provided as one of the private file system options
-available in Parrot. Ever since the design evolved and diverged, taking
-into account the works on HTTP-Fuse [7] and content-delivery
-networks [4, 6, 9]. Its current implementation provides the following
-key features:
+The first implementation of CernVM-FS was based on grow-fs
+[Compostella10]_ [Thain05]_, which was originally provided as one of
+the private file system options available in Parrot. Ever since the
+design evolved and diverged, taking into account the works on HTTP-
+Fuse [Suzaki06]_ and content-delivery networks [Freedman03]_
+[Nygren10]_ [Tolia03]_. Its current implementation provides the
+following key features:
 
--  Use of the the Fuse kernel module that comes with in-kernel caching
-   of file data and file attributes
+-  Use of the the `Fuse kernel module <http://fuse.sourceforge.net>`_
+   that comes with in-kernel caching of file data and file attributes
 
 -  Cache quota management
 
@@ -77,7 +79,7 @@ distributed and versioned file-by-file. In order to create and update a
 CernVM-FS repository, a distinguished machine, the so-called *Release
 Manager Machine*, is used. On such a release manager machine, a
 CernVM-FS repository is mounted in read/write mode by means of a union
-file system [10]. The union file system overlays the CernVM-FS read-only
+file system [Wright04]_. The union file system overlays the CernVM-FS read-only
 mount point by a writable scratch area. The CernVM-FS server tool kit
 merges changes written to the scratch area into the
 CernVM-FS repository. Merging and publishing changes can be triggered at
@@ -98,126 +100,3 @@ actually used are downloaded and cached.
    cryptographic hash of the corresponding catalog entry. The ``read()``
    and the ``stat()`` system call can be entirely served from the
    in-kernel file system buffers.
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   <div id="ref-rfc1945">
-
-[1] Berners-Lee, T. et al. 1996. *Hypertext Transfer Protocol –
-HTTP/1.0*. Technical Report #1945. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-growfs09">
-
-[2] Compostella, G. et al. 2010. CDF software distribution on the Grid
-using Parrot. *Journal of Physics: Conference Series*. 219, (2010).
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-rfc2616">
-
-[3] Fielding, R. et al. 1999. *Hypertext Transfer Protocol – HTTP/1.1*.
-Technical Report #2616. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-coral03">
-
-[4] Freedman, M.J. and Mazières, D. 2003. Sloppy hashing and
-self-organizing clusters. M.F. Kaashoek and I. Stoica, eds. Springer.
-45–55.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-fuse">
-
-[5] Henk, C. and Szeredi, M. Filesystem in Userspace (FUSE).
-http://fuse.sourceforge.net.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-akamai10">
-
-[6] Nygren, E. et al. 2010. The Akamai network: A platform for
-high-performance internet applications. *ACM SIGOPS Operating Systems
-Review*. 44, 3 (2010), 2–19.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-httpfuse06">
-
-[7] Suzaki, K. et al. 2006. HTTP-FUSE Xenoppix. *Proc. of the 2006 linux
-symposium* (2006), 379–392.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-parrot05">
-
-[8] Thain, D. and Livny, M. 2005. Parrot: an application environment for
-data-intensive computing. *Scalable Computing: Practice and Experience*.
-6, 3 (18 2005), 9.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-caspar03">
-
-[9] Tolia, N. et al. 2003. Opportunistic use of content addressable
-storage for distributed file systems. *Proc. of the uSENIX annual
-technical conference* (2003).
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-unionfs04">
-
-[10] Wright, C.P. et al. 2004. *Versatility and unix semantics in a
-fan-out unification file system*. Technical Report #FSL-04-01b. Stony
-Brook University.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>

--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -9,14 +9,15 @@ openSuSE 13.1, Fedora 19–21, or Mac OS X \ :math:`\geq 10.8`.
 Getting the Software
 --------------------
 
-The CernVM-FS source code and binary packages are available under
-https://cernvm.cern.ch/portal/downloads. Binary packages are produced
-for rpm, dpkg, and Mac OS X (.pkg). yum repositories for 64 bit and 32
-bit Scientific Linux 5 and 6 and 64 bit Scientific Linux 7 are available
-under http://cvmrepo.web.cern.ch/cvmrepo/yum. The ``cvmfs-release``
-packages can be used to add a these yum repositories to the local
-yum installation. The ``cvmfs-release`` packages are available under
-https://cernvm.cern.ch/portal/downloads.
+The CernVM-FS source code and binary packages are available `on our
+website <https://cernvm.cern.ch/portal/filesystem/downloads>`_. Binary
+packages are produced for rpm, dpkg, and Mac OS X (.pkg). yum
+repositories for 64 bit and 32 bit Scientific Linux 5 and 6 and 64 bit
+Scientific Linux 7 are available as a `yum repository
+<http://cvmrepo.web.cern.ch/cvmrepo/yum>`_. The ``cvmfs-release``
+packages can be used to add a these yum repositories to the local yum
+installation. The ``cvmfs-release`` packages are available on `our
+download page <https://cernvm.cern.ch/portal/filesystem/downloads>`_.
 
 The CernVM-FS client is not relocatable and needs to be installed under
 /usr. On Intel architectures, it needs a gcc :math:`\geq 4.2` compiler,
@@ -87,9 +88,9 @@ To install, proceed according to the following steps:
 Mac OS X
 ~~~~~~~~
 
-On Mac OS X, CernVM-FS is based on OSXFuse\  [1]_. It is not integrated
-with autofs. In order to install, proceed according to the following
-steps:
+On Mac OS X, CernVM-FS is based on `OSXFuse <http://osxfuse.github.io>`_.
+It is not integrated with autofs. In order to install, proceed according
+to the following steps:
 
 **Step 1**
     Install the CernVM-FS package by opening the .pkg file.
@@ -128,7 +129,7 @@ Usage
 The CernVM-FS repositories are located under /cvmfs. Each repository is
 identified by a *fully qualified repository name*. The fully qualified
 repository name consists of a repository identifier and a domain name,
-similar to DNS records [1]. The domain part of the fully qualified
+similar to DNS records [Mockapetris87]_. The domain part of the fully qualified
 repository name indicates the location of repository creation and
 maintenance. For the ATLAS experiment software, for instance, the fully
 qualified repository name is atlas.cern.ch although the hosting web
@@ -187,25 +188,3 @@ In case you need additional assistance, please don’t hesitate to contact
 us at `cernvm.support@cern.ch <cernvm.support@cern.ch>`__. Together with
 the problem description, please send the system information tarball
 created by ``cvmfs_config bugreport``.
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   <div id="ref-rfc1035">
-
-[1] Mockapetris, P. 1987. *Domain names - implementation and
-specification*. Technical Report #1035. Internet Engineering Task Force.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>
-
-.. [1]
-   http://osxfuse.github.io

--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -104,7 +104,7 @@ The following lines should appear accordingly in /etc/squid/squid.conf:
       maximum_object_size 1024 MB
       maximum_object_size_in_memory 128 KB
 
-| 
+|
 | Note that ``http_access allow all`` has to be inserted before (or
   instead of) the line ``http_access deny all``. If Apache is running on
   the same host, the ``APACHE_HOSTNAME`` will be ``localhost``. Also, in

--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -142,11 +142,3 @@ load.
 Keep an eye on HTTP 404 errors. For normal CernVM-FS traffic, such
 failures should not occur. Traffic from CernVM-FS clients is marked by
 an ``X-CVMFS2`` header.
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   </div>

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -20,8 +20,8 @@ snapshots.
 
 In order to provide a writable CernVM-FS repository, CernVM-FS uses a union
 file system that combines a read-only CernVM-FS mount point with a writable
-scratch area [1, 2]. :ref:`This figure below <fig_updateprocess>` outlines the
-process of publishing a repository.
+scratch area [Wright04]_. :ref:`This figure below <fig_updateprocess>` outlines
+the process of publishing a repository.
 
 CernVM-FS Server Quick-Start Guide
 ----------------------------------
@@ -86,10 +86,12 @@ Backup Policy
 Installing the AUFS-enabled Kernel on Scientific Linux 6
 --------------------------------------------------------
 
-CernVM-FS uses the union file-system aufs [1] to efficiently determine
-file-system tree updates while publishing repository transactions on the
-server (see Figure :ref:`below <fig_updateprocess>`). Note that this is *only*
-required on a CernVM-FS server and *not* on the client machines.
+CernVM-FS uses the union file-system `aufs
+<http://aufs.sourceforge.net>`_ to efficiently determine file-system
+tree updates while publishing repository transactions on the server
+(see Figure :ref:`below <fig_updateprocess>`). Note that this is
+*only* required on a CernVM-FS server and *not* on the client
+machines.
 
 | We provide customised kernel packages for Scientific Linux 6 (see
   Appendix ":ref:`apx_rpms`") and keep them up-to-date with upstream kernel
@@ -97,8 +99,8 @@ required on a CernVM-FS server and *not* on the client machines.
   repository.
 | Please follow these steps to install the provided customised kernel:
 
-#. Download the latest cvmfs-release package from the CernVM
-   website [1]_
+#. Download the latest cvmfs-release package from `the CernVM website
+   <https://cernvm.cern.ch/portal/filesystem/downloads>`_
 
 #. | Install the cvmfs-release package:
      ``yum install cvmfs-release*.rpm``
@@ -135,10 +137,11 @@ Publishing a new Repository Revision
    renamed to their cryptographic content hash before copied into the
    data store.
 
-Since the repositories may contain many file system objects [2]_, we
+Since the repositories may contain many file system objects, we
 cannot afford to generate an entire repository from scratch for every
 update. Instead, we add a writable file system layer on top of a mounted
-read-only CernVM-FS repository using the union file system aufs [1].
+read-only CernVM-FS repository using the union file system `aufs
+<http://aufs.sourceforge.net>`_.
 This renders a read-only CernVM-FS mount point writable to the user,
 while all performed changes are stored in a special writable scratch
 area managed by aufs. A similar approach is used by Linux Live
@@ -152,7 +155,7 @@ directories in the writable volume as well. Additionally it creates
 special hidden files (called *white-outs*) to keep track of file
 deletions in the CernVM-FS repository.
 
-Eventually, all changes applied to the repository are stored in aufs\ ’s
+Eventually, all changes applied to the repository are stored in aufs’s
 scratch area and can be merged into the actual CernVM-FS repository by a
 subsequent synchronization step. Up until the actual synchronization
 step takes place, no changes are applied to the CernVM-FS repository.
@@ -963,43 +966,3 @@ in the repository just like any other files that have identical content.
 Note that if, in a subsequent publish operation, only one of these
 cross-directory hardlinks gets changed, the other hardlinks remain
 unchanged (the hardlink got “broken”).
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   <div id="ref-aufs">
-
-[1] Okajima, J.R. Aufs - Advanced multi layered Unification FileSystem.
-http://aufs.sourceforge.net/.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-unionfs04">
-
-[2] Wright, C.P. et al. 2004. *Versatility and unix semantics in a
-fan-out unification file system*. Technical Report #FSL-04-01b. Stony
-Brook University.
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>
-
-.. [1]
-   CernVM-FS download page:
-   http://cernvm.cern.ch/portal/filesystem/downloads
-
-.. [2]
-   For ATLAS, for example, “many” means order of :math:`10^7` file
-   system objects (number of regular files, symbolic links, and
-   directories).

--- a/cpt-squid.rst
+++ b/cpt-squid.rst
@@ -4,10 +4,10 @@ Setting up a Local Squid Proxy
 ==============================
 
 For clusters of nodes with CernVM-FS clients, we strongly recommend to
-setup two or more Squid\  [1]_ forward proxy servers as well. The
-forward proxies will reduce the latency for the local worker nodes,
-which is critical for cold cache performance. They also reduce the load
-on the Stratum 1 servers.
+setup two or more `Squid forward proxy <http://www.squid-
+cache.org>`_ servers as well. The forward proxies will reduce the
+latency for the local worker nodes, which is critical for cold cache
+performance. They also reduce the load on the Stratum 1 servers.
 
 From what we have seen, a Squid server on commodity hardware scales well
 for at least a couple of hundred worker nodes. The more RAM and hard
@@ -20,10 +20,10 @@ two servers are A and B, set
 
       CVMFS_HTTP_PROXY="http://A:3128|http://B:3128"
 
-Squid is very powerful and has lots of configuration and tuning options.
-For CernVM-FS we require only the very basic static content caching. If
-you already have a *Frontier Squid*\  [2]_ [1, 2] installed you can use
-it as well for CernVM-FS.
+Squid is very powerful and has lots of configuration and tuning
+options. For CernVM-FS we require only the very basic static content
+caching. If you already have a `Frontier Squid <http://frontier.cern.ch>`_ 
+[Blumenfeld08]_ [Dykstra10]_ installed you can use it as well for CernVM-FS.
 
 Otherwise, cache sizes and access control needs to be configured in
 order to use the Squid server with CernVM-FS. In order to do so, browse
@@ -66,40 +66,3 @@ the first service start, the cache space on the hard disk needs to be
 prepared by ``squid -z``. In order to make the increased number of file
 descriptors effective for Squid, execute ``ulimit -n 8192`` prior to
 starting the squid service.
-
-.. raw:: html
-
-   <div id="refs" class="references">
-
-.. raw:: html
-
-   <div id="ref-frontier08">
-
-[1] Blumenfeld, B. et al. 2008. CMS conditions data access using
-FroNTier. *Journal of Physics: Conference Series*. 119, (2008).
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   <div id="ref-frontier10">
-
-[2] Dykstra, D. and Lueking, L. 2010. Greatly improved cache update
-times for conditions data with frontier/Squid. *Journal of Physics:
-Conference Series*. 219, (2010).
-
-.. raw:: html
-
-   </div>
-
-.. raw:: html
-
-   </div>
-
-.. [1]
-   http://www.squid-cache.org
-
-.. [2]
-   http://frontier.cern.ch

--- a/index.rst
+++ b/index.rst
@@ -56,6 +56,7 @@ Additional Information
    apx-parameters
    apx-serverinfra
    apx-rpms
+   apx-references
 
 
 Contact and Authors


### PR DESCRIPTION
This is a back-port of the [reference and citation updates](https://github.com/cvmfs/doc-cvmfs/pull/38) on master. Git is pure magic!