### PR TITLE
FIX: Replace Certain Unicode Characters by ASCII

### DIFF
--- a/apx-parameters.rst
+++ b/apx-parameters.rst
@@ -1,6 +1,6 @@
 .. _apx_paramters:
 
-CernVM-FS Parameters
+CernVM-FS Parameters
 ====================
 
 .. |br| raw:: html

--- a/apx-references.rst
+++ b/apx-references.rst
@@ -14,7 +14,7 @@ References
    (Feburary 1999).
 
 .. [Panagiotou06] Panagiotou, K. and Souza, A. 2006. On adequate performance measures
-   for paging. *Annual ACM Symposium on Theory Of Computing*. 38, (2006), 487–496.
+   for paging. *Annual ACM Symposium on Theory Of Computing*. 38, (2006), 487-496.
 
 .. [Schubert08] Schubert, M. et al. 2008. *Nagios 3 enterprise network monitoring*.
    Syngress.
@@ -26,7 +26,7 @@ References
    Technical Report #3174. Internet Engineering Task Force.
 
 .. [Dobbertin96] Dobbertin, H. et al. 1996. RIPEMD-160: A strengthened version of
-   RIPEMD. Springer. 71–82.
+   RIPEMD. Springer. 71-82.
 
 .. [Bertoni09] Bertoni, G., Daemen, J., Peeters, M. and Van Assche, G., 2009.
    Keccak sponge function family main document.
@@ -50,10 +50,10 @@ References
    fan-out unification file system*. Technical Report #FSL-04-01b.
    Stony Brook University.
 
-.. [BernersLee96] Berners-Lee, T. et al. 1996. *Hypertext Transfer Protocol – HTTP/1.0*.
+.. [BernersLee96] Berners-Lee, T. et al. 1996. *Hypertext Transfer Protocol - HTTP/1.0*.
    Technical Report #1945. Internet Engineering Task Force.
 
-.. [Fielding99] Fielding, R. et al. 1999. *Hypertext Transfer Protocol – HTTP/1.1*.
+.. [Fielding99] Fielding, R. et al. 1999. *Hypertext Transfer Protocol - HTTP/1.1*.
    Technical Report #2616. Internet Engineering Task Force.
 
 .. [Compostella10] Compostella, G. et al. 2010. CDF software distribution on the Grid
@@ -64,14 +64,14 @@ References
    6, 3 (18 2005), 9.
 
 .. [Suzaki06] Suzaki, K. et al. 2006. HTTP-FUSE Xenoppix. *Proc. of the 2006 linux
-   symposium* (2006), 379–392.
+   symposium* (2006), 379-392.
 
 .. [Freedman03] Freedman, M.J. and Mazières, D. 2003. Sloppy hashing and
-   self-organizing clusters. M.F. Kaashoek and I. Stoica, eds. Springer. 45–55.
+   self-organizing clusters. M.F. Kaashoek and I. Stoica, eds. Springer. 45-55.
 
 .. [Nygren10] Nygren, E. et al. 2010. The Akamai network: A platform for
    high-performance internet applications. *ACM SIGOPS Operating Systems
-   Review*. 44, 3 (2010), 2–19.
+   Review*. 44, 3 (2010), 2-19.
 
 .. [Tolia03] Tolia, N. et al. 2003. Opportunistic use of content addressable
    storage for distributed file systems. *Proc. of the uSENIX annual

--- a/apx-rpms.rst
+++ b/apx-rpms.rst
@@ -3,10 +3,10 @@
 Available RPMs
 ==============
 
-The CernVM-FS software is available in form of several RPM packages:
+The CernVM-FS software is available in form of several RPM packages:
 
 **cvmfs-release**
-    Adds the CernVM-FS yum repository.
+    Adds the CernVM-FS yum repository.
 
 **cvmfs-config-default**
     Contains a configuration and public keys suitable for nodes in the
@@ -24,7 +24,7 @@ The CernVM-FS software is available in form of several RPM packages:
 
 **cvmfs-devel**
     Contains the ``libcvmfs.a`` static library and the ``libcvmfs.h``
-    header file for use of CernVM-FS with Parrot [Thain05]_.
+    header file for use of CernVM-FS with Parrot [Thain05]_.
 
 **cvmfs-auto-setup**
     Only available through yum. This is a wrapper for
@@ -32,16 +32,16 @@ The CernVM-FS software is available in form of several RPM packages:
     configuration for the ATLAS Tier3s. Depends on cvmfs.
 
 **cvmfs-server**
-    Contains the CernVM-FS server tool kit for maintaining Stratum 0 and
-    Stratum 1 servers.
+    Contains the CernVM-FS server tool kit for maintaining Stratum 0 and
+    Stratum 1 servers.
 
 **kernel-\ :math:`\cdots`-.aufs21**
     Scientific Linux 6 kernel with aufs. Required for SL6 based
-    Stratum 0 servers.
+    Stratum 0 servers.
 
 **kernel-\ :math:`\cdots`-.aufs3**
     Scientific Linux 7 kernel with aufs. Required for SL7/CC7 based
-    Stratum 0 servers.
+    Stratum 0 servers.
 
 **cvmfs-unittests**
     Contains the ``cvmfs_unittests`` binary. Only required for testing.

--- a/apx-serverinfra.rst
+++ b/apx-serverinfra.rst
@@ -146,9 +146,9 @@ Repository Configuration Directory
 
 The authoritative configuration of a CernVM-FS repository is located in
 ``/etc/cvmfs/repositories.d`` and should only be writable by the
-administrator. Furthermore the repository’s keychain is located in
+administrator. Furthermore the repository's keychain is located in
 ``/etc/cvmfs/keys`` and follows the naming convention ``<fqrn>.crt`` for
-the certificate, ``<fqrn>.key`` for the repository’s private key and
+the certificate, ``<fqrn>.key`` for the repository's private key and
 ``<fqrn>.pub`` for the public key. All of those files can be symlinked
 somewhere else if necessary.
 

--- a/apx-serverinfra.rst
+++ b/apx-serverinfra.rst
@@ -4,10 +4,10 @@
 
 .. _apx_serverinfra:
 
-CernVM-FS Server Infrastructure
+CernVM-FS Server Infrastructure
 ===============================
 
-This section provides technical details on the CernVM-FS server setup
+This section provides technical details on the CernVM-FS server setup
 including the infrastructure necessary for an individual repository. It
 is highly recommended to first consult ":ref:`sct_serveranatomy`" for a
 more general overview of the involved directory structure.
@@ -15,11 +15,11 @@ more general overview of the involved directory structure.
 Prerequisites
 -------------
 
-A CernVM-FS server installation depends on the following environment
+A CernVM-FS server installation depends on the following environment
 setup and tools to be in place:
 
--  kernel 4.2.x or later (for OverlayFS) *or* aufs support built into
-   the kernel (see Section :ref:`sct_customkernelinstall`)
+-  kernel 4.2.x or later (for OverlayFS) *or* aufs support built into
+   the kernel (see Section :ref:`sct_customkernelinstall`)
 
 -  Backend storage location available through HTTP
 
@@ -31,7 +31,7 @@ setup and tools to be in place:
 Local Backend Storage Infrastructure
 ------------------------------------
 
-CernVM-FS stores the entire repository content (file content and
+CernVM-FS stores the entire repository content (file content and
 meta-data catalogs) into a content addressable storage (CAS). This
 storage can either be a file system at ``/srv/cvmfs`` or an S3
 compatible object storage system (see ":ref:`sct_s3storagesetup`" for
@@ -83,7 +83,7 @@ scratch area of a Stratum0 or specifically a release manager machine
 installation. It is always located inside ``/var/spool/cvmfs`` with
 directories for individual repositories. Note that the data volume of
 the spool area can grow very large for massive repository updates since
-it contains the writable union file system branch and a CernVM-FS client
+it contains the writable union file system branch and a CernVM-FS client
 cache directory.
 
 ========================================= =================================================
@@ -144,7 +144,7 @@ cache directory.
 Repository Configuration Directory
 ----------------------------------
 
-The authoritative configuration of a CernVM-FS repository is located in
+The authoritative configuration of a CernVM-FS repository is located in
 ``/etc/cvmfs/repositories.d`` and should only be writable by the
 administrator. Furthermore the repository’s keychain is located in
 ``/etc/cvmfs/keys`` and follows the naming convention ``<fqrn>.crt`` for
@@ -186,26 +186,26 @@ somewhere else if necessary.
 Environment Setup
 -----------------
 
-Apart from file and directory locations a CernVM-FS server installation
+Apart from file and directory locations a CernVM-FS server installation
 depends on a few environment configurations. Most notably the
 possibility to access the backend storage through HTTP and to allow for
-mounting of both the CernVM-FS client at
-``/var/spool/cvmfs/<fqrn>/rdonly`` and a union file system on ``/cvmfs/<fqrn>``.
+mounting of both the CernVM-FS client at
+``/var/spool/cvmfs/<fqrn>/rdonly`` and a union file system on ``/cvmfs/<fqrn>``.
 
 Granting HTTP access can happen in various ways and depends on the
 chosen backend storage type. For an S3 hosted backend storage, the
-CernVM-FS client can usually be directly pointed to the S3 bucket used
+CernVM-FS client can usually be directly pointed to the S3 bucket used
 for storage (see ":ref:`sct_s3storagesetup`" for details). In case of a
 local file system backend any web server can be used for this purpose.
-By default CernVM-FS assumes Apache and uses that automatically.
+By default CernVM-FS assumes Apache and uses that automatically.
 
-Internally the CernVM-FS server uses a SUID binary (i.e.
+Internally the CernVM-FS server uses a SUID binary (i.e.
 ``cvmfs_suid_helper``) to manipulate its mount points. This is necessary
-since transactional CernVM-FS commands must be accessible to the
+since transactional CernVM-FS commands must be accessible to the
 repository owner that is usually different from root. Both the mount
 directives for ``/var/spool/cvmfs/<fqrn>/rdonly`` and ``/cvmfs/<fqrn>``
 must be placed into ``/etc/fstab`` for this reason. By default
-CernVM-FS uses the following entries for these mount points:
+CernVM-FS uses the following entries for these mount points:
 
 ::
 

--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -4,8 +4,8 @@ Client Configuration
 Structure of /etc/cvmfs
 -----------------------
 
-The local configuration of CernVM-FS is controlled by several files in
-``/etc/cvmfs`` listed in the table below. For every .conf file
+The local configuration of CernVM-FS is controlled by several files in
+``/etc/cvmfs`` listed in the table below. For every .conf file
 except for the files in /etc/cvmfs/default.d you can create a
 corresponding .local file having the same prefix in order to customize
 the configuration. The .local file will be sourced after the
@@ -18,7 +18,7 @@ and perhaps the cache directory and the cache quota (see
 :ref:sct_cache`) In a few cases, one might change a parameter
 for a specific domain or a specific repository, provide an exclusive cache for
 a specific repository (see :ref:sct_cache`). For a list of all
-parameters, see Appendix ":ref:`apxsct_clientparameters`".
+parameters, see Appendix ":ref:`apxsct_clientparameters`".
 
 The .conf and .local configuration files are key-value pairs in the form
 ``PARAMETER=value``. They are sourced by /bin/sh. Hence, a limited set
@@ -55,7 +55,7 @@ The “Config Repository”
 
 In addition to the local system configuration, a client can configure a
 dedicated “config repository”. A config repository is a standard
-mountable CernVM-FS repository that resembles the directory structure of
+mountable CernVM-FS repository that resembles the directory structure of
 /etc/cvmfs. It can be used to centrally maintain the public keys and
 configuration of repositories that should not be distributed with rather
 static packages. Configuration from the config repository is overwritten
@@ -66,12 +66,12 @@ configuration sets this parameter to cvmfs-config.cern.ch.
 Mounting
 --------
 
-Mounting of CernVM-FS repositories is typically handled by autofs. Just
+Mounting of CernVM-FS repositories is typically handled by autofs. Just
 by accessing a repository directory under /cvmfs (/cvmfs/atlas.cern.ch),
-autofs will take care of mounting. autofs will also automatically
+autofs will take care of mounting. autofs will also automatically
 unmount a repository if it is not used for a while.
 
-Instead of using autofs, CernVM-FS repositories can be mounted manually
+Instead of using autofs, CernVM-FS repositories can be mounted manually
 with the system’s ``mount`` command. In order to do so, use the
 ``cvmfs`` file system type, like
 
@@ -79,16 +79,16 @@ with the system’s ``mount`` command. In order to do so, use the
 
       mount -t cvmfs atlas.cern.ch /cvmfs/atlas.cern.ch
 
-Likewise, CernVM-FS repositories can be mounted through entries in
+Likewise, CernVM-FS repositories can be mounted through entries in
 /etc/fstab. A sample entry in /etc/fstab:
 
 ::
 
       atlas.cern.ch /mnt/test cvmfs defaults 0 0
 
-Every mount point corresponds to a CernVM-FS process. Using autofs or
+Every mount point corresponds to a CernVM-FS process. Using autofs or
 the system’s mount command, every repository can only be mounted once.
-Otherwise multiple CernVM-FS processes would collide in the same cache
+Otherwise multiple CernVM-FS processes would collide in the same cache
 location. If a repository is needed under several paths, use a *bind
 mount* or use a :ref:`private file system mount point <sct_privatemount>`.
 
@@ -98,17 +98,17 @@ Private Mount Points
 ~~~~~~~~~~~~~~~~~~~~
 
 In contrast to the system’s ``mount`` command which requires root
-privileges, CernVM-FS can also be mounted like other Fuse file systems
-by normal users. In this case, CernVM-FS uses parameters from one or
+privileges, CernVM-FS can also be mounted like other Fuse file systems
+by normal users. In this case, CernVM-FS uses parameters from one or
 several user-provided config files instead of using the files under
-/etc/cvmfs. CernVM-FS private mount points do not appear as ``cvmfs2``
+/etc/cvmfs. CernVM-FS private mount points do not appear as ``cvmfs2``
 file systems but as ``fuse`` file systems. The ``cvmfs_config`` and
-``cvmfs_talk`` commands ignore privately mounted CernVM-FS repositories.
+``cvmfs_talk`` commands ignore privately mounted CernVM-FS repositories.
 On an interactive machine, private mount points are for instance
-unaffected by an administrator unmounting all system’s CernVM-FS mount
+unaffected by an administrator unmounting all system’s CernVM-FS mount
 points by ``cvmfs_config umount``.
 
-In order to mount CernVM-FS privately, use the ``cvmfs2`` command like
+In order to mount CernVM-FS privately, use the ``cvmfs2`` command like
 
 ::
 
@@ -126,9 +126,9 @@ A minimal sample myparams.conf file could look like this:
 
 Make sure to use absolute path names for the mount point and for the
 cache directory. Use ``fusermount -u`` in order to unmount a privately
-mounted CernVM-FS repository.
+mounted CernVM-FS repository.
 
-The private mount points can also be used to use the CernVM-FS Fuse
+The private mount points can also be used to use the CernVM-FS Fuse
 module in case it has not been installed under /usr and /etc. If the
 public keys are not installed under /etc/cvmfs/keys, the directory of
 the keys needs to be specified in the config file by
@@ -139,19 +139,19 @@ variable has to be set accordingly for the ``cvmfs2`` command.
 Docker Containers
 ~~~~~~~~~~~~~~~~~
 
-There are two options to mount CernVM-FS in docker containers. The first
+There are two options to mount CernVM-FS in docker containers. The first
 option is to bind mount a mounted repository as a volume into the
-container. This has the advantage that the CernVM-FS cache is shared
+container. This has the advantage that the CernVM-FS cache is shared
 among multiple containers. The second option is to mount a repository
 inside a container, which requires a *privileged* container.
 
-In both cases, autofs should not be used. Docker has often issues with
+In both cases, autofs should not be used. Docker has often issues with
 autofs.
 
 Bind mount from the host
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to bind mount a repository from the host, turn off autofs on
+In order to bind mount a repository from the host, turn off autofs on
 the host and mount the repository manually, like:
 
 ::
@@ -162,7 +162,7 @@ the host and mount the repository manually, like:
     mount -t cvmfs sft.cern.ch /cvmfs/sft.cern.ch
 
 Start the docker container with the ``-v`` option to mount the
-CernVM-FS repository inside, like
+CernVM-FS repository inside, like
 
 ::
 
@@ -181,21 +181,21 @@ started in privileged mode, like
 
         docker run --privileged -i -t centos /bin/bash
 
-In such a container, CernVM-FS can be installed and used the usual way
-provided that autofs is turned off.
+In such a container, CernVM-FS can be installed and used the usual way
+provided that autofs is turned off.
 
 Parrot Connector to CernVM-FS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case Fuse cannot be be installed, the `parrot toolkit
+In case Fuse cannot be be installed, the `parrot toolkit
 <http://ccl.cse.nd.edu/software/parrot>`_ provides a means to “mount”
-CernVM-FS on Linux in pure user space.
-Parrot sandboxes an application in a similar way gdb sandboxes an
+CernVM-FS on Linux in pure user space.
+Parrot sandboxes an application in a similar way gdb sandboxes an
 application. But instead of debugging the application,
-parrot transparently rewrites file system calls and can effectively
+parrot transparently rewrites file system calls and can effectively
 provide /cvmfs to an application. We recommend to use the `latest
 precompiled parrot <http://ccl.cse.nd.edu/software/downloadfiles.php>`_, which
-has CernVM-FS support built-in.
+has CernVM-FS support built-in.
 
 In order to sandbox a command ``<CMD>`` with options ``<OPTIONS>`` in
 parrot, use
@@ -224,7 +224,7 @@ one can write
 
 given that the repository public keys are in the provided paths.
 
-By default, parrot uses a shared CernVM-FS cache for all parrot
+By default, parrot uses a shared CernVM-FS cache for all parrot
 instances of the same user stored under a temporary directory that is
 derived from the user id. In order to place the CernVM-FS cache into a
 different directory, use
@@ -241,17 +241,17 @@ belong to the same UNIX group.
 Network Settings
 ----------------
 
-CernVM-FS uses HTTP for the data transfer. Repository data can be
+CernVM-FS uses HTTP for the data transfer. Repository data can be
 replicated to multiple web servers and cached by standard web proxies
-such as Squid [Guerrero99]_. In a typical setup, repositories are replicated to
+such as Squid [Guerrero99]_. In a typical setup, repositories are replicated to
 a handful of web servers in different locations. These replicas form the
-CernVM-FS Stratum 1 service, whereas the replication source server is
-the CernVM-FS Stratum 0 server. In every cluster of client machines,
-there should be two or more web proxy servers that CernVM-FS can use
+CernVM-FS Stratum 1 service, whereas the replication source server is
+the CernVM-FS Stratum 0 server. In every cluster of client machines,
+there should be two or more web proxy servers that CernVM-FS can use
 (see :ref:`cpt_squid`). These site-local web proxies reduce the
-network latency for the CernVM-FS clients and they reduce the load for
-the Stratum 1 service. CernVM-FS supports WPAD/PAC proxy auto
-configuration [Gauthier99]_, choosing a random proxy for load-balancing, and
+network latency for the CernVM-FS clients and they reduce the load for
+the Stratum 1 service. CernVM-FS supports WPAD/PAC proxy auto
+configuration [Gauthier99]_, choosing a random proxy for load-balancing, and
 automatic fail-over to other hosts and proxies in case of network
 errors. Roaming clients can connect directly to the Stratum 1 service.
 
@@ -261,7 +261,7 @@ Stratum 1 List
 To specify the Stratum 1 servers, set ``CVMFS_SERVER_URL`` to a
 semicolon-separated list of known replica servers (enclose in quotes).
 The so defined URLs are organized as a ring buffer. Whenever download of
-files fails from a server, CernVM-FS automatically switches to the next
+files fails from a server, CernVM-FS automatically switches to the next
 mirror server. For repositories under the cern.ch domain, the Stratum 1
 servers are specified in /etc/cvmfs/domain.d/cern.ch.conf.
 
@@ -287,15 +287,15 @@ cms, …).
 Proxy Lists
 ~~~~~~~~~~~
 
-CernVM-FS uses a dedicated HTTP proxy configuration, independent from
-system-wide settings. Instead of a single proxy, CernVM-FS uses a *chain
-of load-balanced proxy groups*. The CernVM-FS proxies are set by the
+CernVM-FS uses a dedicated HTTP proxy configuration, independent from
+system-wide settings. Instead of a single proxy, CernVM-FS uses a *chain
+of load-balanced proxy groups*. The CernVM-FS proxies are set by the
 ``CVMFS_HTTP_PROXY`` parameter.
 
 Proxies within the same proxy group are considered as a load-balance
 group and a proxy is selected randomly. If a proxy fails,
-CernVM-FS automatically switches to another proxy from the current
-group. If all proxies from a group have failed, CernVM-FS switches to
+CernVM-FS automatically switches to another proxy from the current
+group. If all proxies from a group have failed, CernVM-FS switches to
 the next proxy group. After probing the last proxy group in the chain,
 the first proxy is probed again. To avoid endless loops, for each file
 download the number of switches is restricted by the total number of
@@ -312,8 +312,8 @@ order to mount. If you don’t use proxies, set the parameter to
 
 Multiple proxy groups are often organized as a primary proxy group at
 the local site and backup proxy groups at remote sites. In order to
-avoid CernVM-FS being stuck with proxies at a remote site after a
-fail-over, CernVM-FS will automatically retry to use proxies from the
+avoid CernVM-FS being stuck with proxies at a remote site after a
+fail-over, CernVM-FS will automatically retry to use proxies from the
 primary group after some time. The delay for re-trying a proxies from
 the primary group is set in seconds by ``CVMFS_PROXY_RESET_AFTER``. The
 distinction of primary and backup proxy groups can be turned off by
@@ -325,12 +325,12 @@ Automatic Proxy Configuration
 The proxy settings can be automatically gathered through WPAD. The
 special proxy server “auto” in ``CVMFS_HTTP_PROXY`` is resolved
 according to the proxy server specification loaded from a PAC file. PAC
-files can be on a file system or accessible via HTTP. CernVM-FS looks
+files can be on a file system or accessible via HTTP. CernVM-FS looks
 for PAC files in the order given by the semicolon separated URLs in the
 ``CVMFS_PAC_URLS`` environment variable. This variable defaults to
 http://wpad/wpad.dat. The ``auto`` keyword used as a URL in
 ``CVMFS_PAC_URLS`` is resolved to http://wpad/wpad.dat, too, in order to
-be compatible with Frontier [Blumenfeld08]_.
+be compatible with Frontier [Blumenfeld08]_.
 
 Fallback Proxy List
 ~~~~~~~~~~~~~~~~~~~
@@ -349,21 +349,21 @@ see the next section.
 Ordering of Servers according to Geographic Proximity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-CernVM-FS Stratum 1 servers provide a RESTful service for geographic
+CernVM-FS Stratum 1 servers provide a RESTful service for geographic
 ordering. Clients can request
 `http://<HOST>/cvmfs/<FQRN>/api/v1.0/geo/<proxy\_address>/<server\_list>`
 The proxy address can be replaced by a UUID if no proxies are used, and
-the CernVM-FS client does that if there are no regular proxies. The
+the CernVM-FS client does that if there are no regular proxies. The
 server list is comma-separated. The result is an ordered list of indexes
 of the input host names. Use of this API can be enabled in a
-CernVM-FS client with ``CVMFS_USE_GEOAPI=yes``. That will geographically
+CernVM-FS client with ``CVMFS_USE_GEOAPI=yes``. That will geographically
 sort both the servers set by ``CVMFS_SERVER_URL`` and the fallback
 proxies set by ``CVMFS_FALLBACK_PROXY``.
 
 Timeouts
 ~~~~~~~~
 
-CernVM-FS tries to gracefully recover from broken network links and
+CernVM-FS tries to gracefully recover from broken network links and
 temporarily overloaded paths. The timeout for connection attempts and
 for very slow downloads can be set by ``CVMFS_TIMEOUT`` and
 ``CVMFS_TIMEOUT_DIRECT``. The two timeout parameters apply to a
@@ -374,11 +374,11 @@ can be adjusted with the ``CVMFS_LOW_SPEED_LIMIT`` parameter. A very
 slow download is treated like a broken connection.
 
 On timeout errors and on connection failures (but not on name resolving
-failures), CernVM-FS will retry the path using an exponential backoff.
+failures), CernVM-FS will retry the path using an exponential backoff.
 This introduces a jitter in case there are many concurrent requests by a
 cluster of nodes, allowing a proxy server or web server to serve all the
 nodes consecutively. ``CVMFS_MAX_RETRIES`` sets the number of retries on
-a given path before CernVM-FS tries to switch to another proxy or host.
+a given path before CernVM-FS tries to switch to another proxy or host.
 The overall number of requests with a given proxy/host combination is
 ``$CVMFS_MAX_RETRIES``\ +1. ``CVMFS_BACKOFF_INIT`` sets the maximum
 initial backoff in seconds. The actual initial backoff is picked with
@@ -392,9 +392,9 @@ Cache Settings
 --------------
 
 Downloaded files will be stored in a local cache directory. The
-CernVM-FS cache has a soft quota; as a safety margin, the partition
+CernVM-FS cache has a soft quota; as a safety margin, the partition
 hosting the cache should provide more space than the soft quota limit.
-Once the quota limit is reached, CernVM-FS will automatically remove
+Once the quota limit is reached, CernVM-FS will automatically remove
 files from the cache according to the least recently used policy
 [Panagiotou06]_.
 Removal of files is performed bunch-wise until half of the maximum cache
@@ -412,12 +412,12 @@ location of the cache directory can be set by ``CVMFS_CACHE_BASE``.
 
 On SELinux enabled systems, the cache directory and its content need to
 be labeled as ``cvmfs_cache_t``. During the installation of
-CernVM-FS RPMs, this label is set for the default cache directory
+CernVM-FS RPMs, this label is set for the default cache directory
 /var/lib/cvmfs. For other directories, the label needs to be set
-manually by ``chcon -Rv --type=cvmfs_cache_t $CVMFS_CACHE_BASE``.
+manually by ``chcon -Rv --type=cvmfs_cache_t $CVMFS_CACHE_BASE``.
 
 Each repository can either have an exclusive cache or join the
-CernVM-FS shared cache. The shared cache enforces a common quota for all
+CernVM-FS shared cache. The shared cache enforces a common quota for all
 repositories used on the host. File duplicates across repositories are
 stored only once in the shared cache. The quota limit of the shared
 directory should be at least the maximum of the recommended limits of
@@ -437,9 +437,9 @@ cache directory is still used to store control files.
 
 The alien cache directory is set by the ``CVMFS_ALIEN_CACHE`` option. It
 can be located anywhere including cluster and network file systems. If
-configured, all data chunks are stored there. CernVM-FS ensures atomic
+configured, all data chunks are stored there. CernVM-FS ensures atomic
 access to the cache directory. It is safe to have the alien directory
-shared by multiple CernVM-FS processes and it is safe to unlink files
+shared by multiple CernVM-FS processes and it is safe to unlink files
 from the alien cache directory anytime. The contents of files, however,
 must not be touched by third-party programs.
 
@@ -448,7 +448,7 @@ the alien cache files are stored in mode 0660. So all users being part
 of the alien cache directory’s owner group can use it.
 
 The skeleton of the alien cache directory should be created upfront.
-Otherwise, the first CernVM-FS process accessing the alien cache
+Otherwise, the first CernVM-FS process accessing the alien cache
 determines the ownership. The ``cvmfs2`` binary can create such a
 skeleton using
 
@@ -463,7 +463,7 @@ ever-growing. The ``CVMFS_ALIEN_CACHE`` requires
 
 The alien cache might be used in combination with a special repository
 replication mode that preloads a cache directory
-(Section :ref:`cpt_replica`). This allows to propagate an entire repository
+(Section :ref:`cpt_replica`). This allows to propagate an entire repository
 into the cache of a cluster file system for HPC setups that do not allow
 outgoing connectivity.
 
@@ -471,7 +471,7 @@ NFS Server Mode
 ---------------
 
 In case there is no local hard disk space available on a cluster of
-worker nodes, a single CernVM-FS client can be exported via
+worker nodes, a single CernVM-FS client can be exported via
 nfs [Callaghan95]_ [Shepler03]_ to these worker nodes.This mode of deployment
 will inevitably introduce a performance bottleneck and a single point of
 failure and should be only used if necessary.
@@ -479,20 +479,20 @@ failure and should be only used if necessary.
 NSF export requires Linux kernel >= 2.6.27 on the NFS server. For
 instance, exporting works for Scientific Linux 6 but not for Scientific
 Linux 5. The NFS server should run a lock server as well. For proper NFS
-support, set ``CVMFS_NFS_SOURCE=yes``. Also, autofs for CernVM-FS needs
+support, set ``CVMFS_NFS_SOURCE=yes``. Also, autofs for CernVM-FS needs
 to be turned off and repositories need to be mounted manually. On the
-client side, all available nfs implementations should work.
+client side, all available nfs implementations should work.
 
 In the NFS mode, upon mount an additionally directory
-nfs\_maps.$repository\_name appears in the CernVM-FS cache directory.
-These *NFS maps* use leveldb to store the virtual inode CernVM-FS issues
+nfs\_maps.$repository\_name appears in the CernVM-FS cache directory.
+These *NFS maps* use leveldb to store the virtual inode CernVM-FS issues
 for any accessed path. The virtual inode may be requested by NFS clients
 anytime later. As the NFS server has no control over the lifetime of
 client caches, entries in the NFS maps cannot be removed.
 
 Typically, every entry in the NFS maps requires some 150-200 Bytes. A
 recursive ``find`` on /cvmfs/atlas.cern.ch with 25 million entries, for
-instance, would add up in the cache directory. For a CernVM-FS instance
+instance, would add up in the cache directory. For a CernVM-FS instance
 that is exported via NFS, the safety margin for the NFS maps needs be
 taken into account. It also might be necessary to monitor the actual
 space consumption.
@@ -500,7 +500,7 @@ space consumption.
 Tuning
 ~~~~~~
 
-The default settings in CernVM-FS are tailored to the normal, non-NFS
+The default settings in CernVM-FS are tailored to the normal, non-NFS
 use case. For decent performance in the NFS deployment, the amount of
 memory given to the meta-data cache should be increased. By default,
 this is 16M. It can be increased, for instance, to 256M by setting
@@ -513,7 +513,7 @@ NFS daemons is set by the ``RPCNFSDCOUNT`` parameter in
 /etc/sysconfig/nfs.
 
 The performance will benefit from large RAM on the NFS server
-(:math:`\geq` 16GB) and CernVM-FS caches hosted on an SSD
+(:math:`\geq` 16GB) and CernVM-FS caches hosted on an SSD
 hard drive.
 
 Shared NFS Maps (HA-NFS)
@@ -521,21 +521,21 @@ Shared NFS Maps (HA-NFS)
 
 As an alternative to the existing, `leveldb
 <https://github.com/google/leveldb>`_ managed NFS maps, the NFS
-maps can optionally be managed out of the CernVM-FS cache directory by
+maps can optionally be managed out of the CernVM-FS cache directory by
 SQLite. This allows the NFS maps to be placed on shared storage and
-accessed by multiple CernVM-FS NFS export nodes simultaneously for
+accessed by multiple CernVM-FS NFS export nodes simultaneously for
 clustering and active high-availablity setups. In order to enable shared
 NFS maps, set ``CVMFS_NFS_SHARED`` to the path that should be used to
-host the SQLite database. If the path is on shared storage, the shared
+host the SQLite database. If the path is on shared storage, the shared
 storage has to support POSIX file locks. The drawback of the
-SQLite managed NFS maps is a significant performance penalty which in
+SQLite managed NFS maps is a significant performance penalty which in
 practice can be covered by the memory caches.
 
 Example
 ~~~~~~~
 
 An example entry /etc/exports (note: the fsid needs to be different for
-every exported CernVM-FS repository)
+every exported CernVM-FS repository)
 
 ::
 
@@ -554,10 +554,10 @@ A sample entry /etc/fstab entry on a client:
 Hotpatching and Reloading
 -------------------------
 
-By hotpatching a running CernVM-FS instance, most of the code can be
+By hotpatching a running CernVM-FS instance, most of the code can be
 reloaded without unmounting the file system. The current active code is
 unloaded and the code from the currently installed binaries is loaded.
-Hotpatching is logged to syslog. Since CernVM-FS is re-initialized
+Hotpatching is logged to syslog. Since CernVM-FS is re-initialized
 during hotpatching and configuration parameters are re-read, hotpatching
 can be also seen as a “reload”.
 
@@ -567,7 +567,7 @@ Hotpatching has to be done for all repositories concurrently by
 
       cvmfs_config [-c] reload
 
-The optional parameter ``-c`` specifies if the CernVM-FS cache should be
+The optional parameter ``-c`` specifies if the CernVM-FS cache should be
 wiped out during the hotpatch. Reloading of the parameters of a specific
 repository can be done like
 
@@ -587,7 +587,7 @@ The currently loaded set of parameters can be shown by
 
       cvmfs_talk parameters
 
-The CernVM-FS packages use hotpatching in the package upgrade process.
+The CernVM-FS packages use hotpatching in the package upgrade process.
 
 .. _sct_tools:
 
@@ -597,11 +597,11 @@ Auxiliary Tools
 cvmfs\_fsck
 ~~~~~~~~~~~
 
-CernVM-FS assumes that the local cache directory is trustworthy.
+CernVM-FS assumes that the local cache directory is trustworthy.
 However, it might happen that files get corrupted in the cache directory
-caused by errors outside the scope of CernVM-FS. CernVM-FS stores files
+caused by errors outside the scope of CernVM-FS. CernVM-FS stores files
 in the local disk cache with their cryptographic content hash key as
-name, which makes it easy to verify file integrity. CernVM-FS contains
+name, which makes it easy to verify file integrity. CernVM-FS contains
 the ``cvmfs_fsck`` utility to do so for a specific cache directory. Its
 return value is comparable to the system’s ``fsck``. For example,
 
@@ -618,7 +618,7 @@ using 8 concurrent threads. Supported options are:
                  cache directory. Defaults to 4.
 ``-p``           Tries to automatically fix problems.
 ``-f``           Unlinks the cache database. The database will be automatically
-                 rebuilt by CernVM-FS on next mount.
+                 rebuilt by CernVM-FS on next mount.
 ================ ===============================================================
 
 cvmfs\_config
@@ -629,15 +629,15 @@ system for use with CernVM-FS.
 
 **setup**
     The ``setup`` command takes care of basic setup tasks, such as
-    creating the cvmfs user and allowing access to CernVM-FS mount
+    creating the cvmfs user and allowing access to CernVM-FS mount
     points by all users.
 
 **chksetup**
     The ``chksetup`` command inspects the system and the
-    CernVM-FS configuration in /etc/cvmfs for common problems.
+    CernVM-FS configuration in /etc/cvmfs for common problems.
 
 **showconfig**
-    The ``showconfig`` command prints the CernVM-FS parameters for all
+    The ``showconfig`` command prints the CernVM-FS parameters for all
     repositories or for the specific repository given as argument.
 
 **stat**
@@ -646,7 +646,7 @@ system for use with CernVM-FS.
 
 **status**
     The ``status`` command shows all currently mounted repositories and
-    the process id (PID) of the CernVM-FS processes managing a mount
+    the process id (PID) of the CernVM-FS processes managing a mount
     point.
 
 **probe**
@@ -655,11 +655,11 @@ system for use with CernVM-FS.
 
 **reload**
     The ``reload`` command is used to :ref:`reload or hotpatch
-    CernVM-FS instances <sct_hotpatch>`.
+    CernVM-FS instances <sct_hotpatch>`.
 
 **umount**
     The ``umount`` command unmounts all currently mounted
-    CernVM-FS repositories, which will only succeed if there are no open
+    CernVM-FS repositories, which will only succeed if there are no open
     file handles on the repositories.
 
 **wipecache**
@@ -673,7 +673,7 @@ cvmfs\_talk
 ~~~~~~~~~~~
 
 The ``cvmfs_talk`` command provides a way to control a currently running
-CernVM-FS process and to extract information about the status of the
+CernVM-FS process and to extract information about the status of the
 corresponding mount point. Most of the commands are for special purposes
 only or covered by more convenient commands, such as
 ``cvmfs_config showconfig`` or ``cvmfs_config stat``. Two commands might
@@ -697,7 +697,7 @@ Other
 ~~~~~
 
 Information about the current cache usage can be gathered using the
-``df`` utility. For repositories created with the CernVM-FS 2.1
+``df`` utility. For repositories created with the CernVM-FS 2.1
 toolchain, information about the overall number of file system entries
 in the repository as well as the number of entries covered by currently
 loaded meta-data can be gathered by ``df -i``.
@@ -710,13 +710,13 @@ Debug Logs
 ----------
 
 The ``cvmfs2`` binary forks a watchdog process on start. Using this
-watchdog, CernVM-FS is able to create a stack trace in case certain
+watchdog, CernVM-FS is able to create a stack trace in case certain
 signals (such as a segmentation fault) are received. The watchdog writes
 the stack trace into syslog as well as into a file ``stacktrace`` in the
 cache directory.
 
 In addition to :ref:`these debugging hints <sct_debugginghints>`, CernVM-FS
-can be started in debug mode. In the debug mode, CernVM-FS will log with high
+can be started in debug mode. In the debug mode, CernVM-FS will log with high
 verbosity which makes the debug mode unsuitable for production use. In order
 to turn on the debug mode, set ``CVMFS_DEBUGFILE=/tmp/cvmfs.log``.
 

--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -23,7 +23,7 @@ parameters, see Appendix ":ref:`apxsct_clientparameters`".
 The .conf and .local configuration files are key-value pairs in the form
 ``PARAMETER=value``. They are sourced by /bin/sh. Hence, a limited set
 of shell commands can be used inside these files including comments,
-``if`` clauses, parameter evaluation, and shell math (``$((…))``).
+``if`` clauses, parameter evaluation, and shell math (``$((...))``).
 Special characters have to be quoted. For instance, instead of
 ``CVMFS_HTTP_PROXY=p1;p2``, write ``CVMFS_HTTP_PROXY='p1;p2'`` in order
 to avoid parsing errors. The shell commands in the configuration files
@@ -275,14 +275,14 @@ trip time measurement.
 
 The special sequence ``@fqrn@`` in the ``CVMFS_SERVER_URL`` string is
 replaced by fully qualified repository name (atlas.cern.cn, cms.cern.ch,
-…). That allows to use the same parameter for many repositories hosted
+...). That allows to use the same parameter for many repositories hosted
 under the same domain. For instance,
 http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@ can resolve to
 http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch,
 http://cvmfs-stratum-one.cern.ch/cvmfs/cms.cern.ch, and so on depending
 on the repository that is being mounted. The same works for the sequence
 ``@org@`` which is replaced by the unqualified repository name (atlas,
-cms, …).
+cms, ...).
 
 Proxy Lists
 ~~~~~~~~~~~

--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -25,7 +25,7 @@ The .conf and .local configuration files are key-value pairs in the form
 of shell commands can be used inside these files including comments,
 ``if`` clauses, parameter evaluation, and shell math (``$((…))``).
 Special characters have to be quoted. For instance, instead of
-``CVMFS_HTTP_PROXY=p1;p2``, write ``CVMFS_HTTP_PROXY=’p1;p2’`` in order
+``CVMFS_HTTP_PROXY=p1;p2``, write ``CVMFS_HTTP_PROXY='p1;p2'`` in order
 to avoid parsing errors. The shell commands in the configuration files
 can use the ``CVMFS_FQRN`` parameter, which contains the fully qualified
 repository names that is being mounted. The current working directory is
@@ -72,7 +72,7 @@ autofs will take care of mounting. autofs will also automatically
 unmount a repository if it is not used for a while.
 
 Instead of using autofs, CernVM-FS repositories can be mounted manually
-with the system’s ``mount`` command. In order to do so, use the
+with the system's ``mount`` command. In order to do so, use the
 ``cvmfs`` file system type, like
 
 ::
@@ -87,7 +87,7 @@ Likewise, CernVM-FS repositories can be mounted through entries in
       atlas.cern.ch /mnt/test cvmfs defaults 0 0
 
 Every mount point corresponds to a CernVM-FS process. Using autofs or
-the system’s mount command, every repository can only be mounted once.
+the system's mount command, every repository can only be mounted once.
 Otherwise multiple CernVM-FS processes would collide in the same cache
 location. If a repository is needed under several paths, use a *bind
 mount* or use a :ref:`private file system mount point <sct_privatemount>`.
@@ -97,7 +97,7 @@ mount* or use a :ref:`private file system mount point <sct_privatemount>`.
 Private Mount Points
 ~~~~~~~~~~~~~~~~~~~~
 
-In contrast to the system’s ``mount`` command which requires root
+In contrast to the system's ``mount`` command which requires root
 privileges, CernVM-FS can also be mounted like other Fuse file systems
 by normal users. In this case, CernVM-FS uses parameters from one or
 several user-provided config files instead of using the files under
@@ -105,7 +105,7 @@ several user-provided config files instead of using the files under
 file systems but as ``fuse`` file systems. The ``cvmfs_config`` and
 ``cvmfs_talk`` commands ignore privately mounted CernVM-FS repositories.
 On an interactive machine, private mount points are for instance
-unaffected by an administrator unmounting all system’s CernVM-FS mount
+unaffected by an administrator unmounting all system's CernVM-FS mount
 points by ``cvmfs_config umount``.
 
 In order to mount CernVM-FS privately, use the ``cvmfs2`` command like
@@ -307,7 +307,7 @@ hostnames [#]_. Multiple IP addresses behind a single proxy host name
 (DNS *round-robin* entry) are automatically transformed into a
 load-balanced group. The ``DIRECT`` keyword for a hostname avoids using
 proxies. Note that the ``CVMFS_HTTP_PROXY`` parameter is necessary in
-order to mount. If you don’t use proxies, set the parameter to
+order to mount. If you don't use proxies, set the parameter to
 ``DIRECT``.
 
 Multiple proxy groups are often organized as a primary proxy group at
@@ -445,7 +445,7 @@ must not be touched by third-party programs.
 
 In contrast to normal cache mode where files are store in mode 0600, in
 the alien cache files are stored in mode 0660. So all users being part
-of the alien cache directory’s owner group can use it.
+of the alien cache directory's owner group can use it.
 
 The skeleton of the alien cache directory should be created upfront.
 Otherwise, the first CernVM-FS process accessing the alien cache
@@ -603,7 +603,7 @@ caused by errors outside the scope of CernVM-FS. CernVM-FS stores files
 in the local disk cache with their cryptographic content hash key as
 name, which makes it easy to verify file integrity. CernVM-FS contains
 the ``cvmfs_fsck`` utility to do so for a specific cache directory. Its
-return value is comparable to the system’s ``fsck``. For example,
+return value is comparable to the system's ``fsck``. For example,
 
 ::
 

--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -50,11 +50,11 @@ set to the parent directory of the configuration file at hand.
                                of file catalogs
 ============================== =================================================
 
-The “Config Repository”
+The "Config Repository"
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to the local system configuration, a client can configure a
-dedicated “config repository”. A config repository is a standard
+dedicated "config repository". A config repository is a standard
 mountable CernVM-FS repository that resembles the directory structure of
 /etc/cvmfs. It can be used to centrally maintain the public keys and
 configuration of repositories that should not be distributed with rather
@@ -188,7 +188,7 @@ Parrot Connector to CernVM-FS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In case Fuse cannot be be installed, the `parrot toolkit
-<http://ccl.cse.nd.edu/software/parrot>`_ provides a means to “mount”
+<http://ccl.cse.nd.edu/software/parrot>`_ provides a means to "mount"
 CernVM-FS on Linux in pure user space.
 Parrot sandboxes an application in a similar way gdb sandboxes an
 application. But instead of debugging the application,
@@ -323,7 +323,7 @@ Automatic Proxy Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The proxy settings can be automatically gathered through WPAD. The
-special proxy server “auto” in ``CVMFS_HTTP_PROXY`` is resolved
+special proxy server "auto" in ``CVMFS_HTTP_PROXY`` is resolved
 according to the proxy server specification loaded from a PAC file. PAC
 files can be on a file system or accessible via HTTP. CernVM-FS looks
 for PAC files in the order given by the semicolon separated URLs in the
@@ -368,7 +368,7 @@ temporarily overloaded paths. The timeout for connection attempts and
 for very slow downloads can be set by ``CVMFS_TIMEOUT`` and
 ``CVMFS_TIMEOUT_DIRECT``. The two timeout parameters apply to a
 connection with a proxy server and to a direct connection to a Stratum 1
-server, respectively. A download is considered to be “very slow” if the
+server, respectively. A download is considered to be "very slow" if the
 transfer rate is below for more than the timeout interval. The threshold
 can be adjusted with the ``CVMFS_LOW_SPEED_LIMIT`` parameter. A very
 slow download is treated like a broken connection.
@@ -428,7 +428,7 @@ the shared cache but use an exclusive cache, set
 Alien Cache
 ~~~~~~~~~~~
 
-An “alien cache” provides the possibility to use a data cache outside
+An "alien cache" provides the possibility to use a data cache outside
 the control of CernVM-FS. This can be necessary, for instance, in HPC
 environments where local disk space is not available or scarce but
 powerful cluster file systems are available. The alien cache directory
@@ -559,7 +559,7 @@ reloaded without unmounting the file system. The current active code is
 unloaded and the code from the currently installed binaries is loaded.
 Hotpatching is logged to syslog. Since CernVM-FS is re-initialized
 during hotpatching and configuration parameters are re-read, hotpatching
-can be also seen as a “reload”.
+can be also seen as a "reload".
 
 Hotpatching has to be done for all repositories concurrently by
 

--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -448,7 +448,7 @@ volume of pinned catalogs exceeds of the overall cache volume.
 
 The cache catalog can be re-constructed from scratch on mount.
 Re-constructing the cache catalog is necessary when the managed cache is
-used for the first time and every time when “unmanaged” changes occurred
+used for the first time and every time when "unmanaged" changes occurred
 to the cache directory, when CernVM-FS was terminated unexpectedly.
 
 In case of an exclusive cache, the cache manager runs as a separate thread of
@@ -582,7 +582,7 @@ readdir
 ~~~~~~~
 
 A directory listing is served by a query on the file catalog. Although the
-“parent”-column is indexed (see :ref:`Catalog table schema <tab_catalog>`),
+"parent"-column is indexed (see :ref:`Catalog table schema <tab_catalog>`),
 this is a relatively slow function. We expect directory listing to happen
 rather seldom.
 
@@ -718,7 +718,7 @@ changes are in fact written to the read-write branch.
 Preserving POSIX semantics in union file systems is non-trivial; the
 first fully functional implementation has been presented by Wright et
 al. [Wright04]_. By now, union file systems are well established for
-“Live CD” builders, which use a RAM disk overlay on top of the read-
+"Live CD" builders, which use a RAM disk overlay on top of the read-
 only system partition in order to provide the illusion of a fully
 read-writable system. CernVM-FS supports both aufs and OverlayFS
 union file systems.

--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -123,7 +123,7 @@ stored in the parent catalog. Therefore, the root catalog fully defines
 an entire repository.
 
 Loading of nested catalogs happens on demand by CernVM-FS on the first
-attempt to access of anything inside, a user won’t see the difference
+attempt to access of anything inside, a user won't see the difference
 between a single large catalog and several nested catalogs. While this
 usually avoids unnecessary catalogs to be loaded, recursive operations
 like ``find`` can easily bypass this optimization.
@@ -165,11 +165,11 @@ Repository Manifest (.cvmfspublished)
 -------------------------------------
 
 Every CernVM-FS repository contains a repository manifest file that
-serves as entry point into the repository’s catalog structure. The
+serves as entry point into the repository's catalog structure. The
 repository manifest is the first file accessed by the CernVM-FS client
 at mount time and therefore must be accessible via HTTP on the
 repository root URL. It is always called **.cvmfspublished** and
-contains fundamental repository meta data like the root catalog’s
+contains fundamental repository meta data like the root catalog's
 cryptographic hash and the repository revision number as a key-value
 list.
 
@@ -209,16 +209,16 @@ meta data fields.
 +-----------+-------------------------------------------------------------+
 | **Field** | **Meta Data Description**                                   |
 +-----------+-------------------------------------------------------------+
-| ``C``     | Cryptographic hash of the repository’s current root catalog |
+| ``C``     | Cryptographic hash of the repository's current root catalog |
 +-----------+-------------------------------------------------------------+
-| ``R``     | MD5 hash of the repository’s root path         |br|         |
+| ``R``     | MD5 hash of the repository's root path         |br|         |
 |           | (usually always ``d41d8cd98f00b204e9800998ecf8427e``)       |
 +-----------+-------------------------------------------------------------+
 | ``B``     | File size of the root catalog in bytes                      |
 +-----------+-------------------------------------------------------------+
 | ``X``     | Cryptographic hash of the signing certificate               |
 +-----------+-------------------------------------------------------------+
-| ``H``     | Cryptographic hash of the repository’s named tag history    |
+| ``H``     | Cryptographic hash of the repository's named tag history    |
 |           | database                                                    |
 +-----------+-------------------------------------------------------------+
 | ``T``     | Unix timestamp of this particular revision                  |
@@ -260,7 +260,7 @@ of the repository.
 The top level hash used for the repository signature can be found in the
 repository manifest right below the separator line (``--`` /
 :ref:`see above <sct_manifeststructure>`).
-It is the cryptographic hash of the manifest’s meta data lines excluding
+It is the cryptographic hash of the manifest's meta data lines excluding
 the separator line. Following the top level hash is the actual signature
 produced by the X.509 certificate signing procedure in binary form.
 
@@ -493,7 +493,7 @@ maps* implement a persistent store of the path names :math:`\mapsto`
 inode mappings. Storing them on hard disk allows for control of the
 CernVM-FS memory consumption (currently :math:`\approx` 45 MB extra)
 and ensures consistency between remounts of CernVM-FS. The performance
-penalty for doing so is small. CernVM-FS uses `Google’s leveldb
+penalty for doing so is small. CernVM-FS uses `Google's leveldb
 <https://github.com/google/leveldb>`, a fast, local key value store.
 Reads and writes are only performed when meta-data are looked up in
 SQLite, in which case the SQLite query supposedly dominates the
@@ -514,7 +514,7 @@ The CernVM-FS Fuse module comprises a minimal *loader* loader process
 (the ``cvmfs2`` binary) and a shared library containing the actual
 Fuse module (``libcvmfs_fuse.so``). This structure makes it possible to
 reload CernVM-FS code and parameters without unmounting the file system.
-Loader and library don’t share any symbols except for two global structs
+Loader and library don't share any symbols except for two global structs
 ``cvmfs_exports`` and ``loader_exports`` used to call each others
 functions. The loader process opens the Fuse channel and implements stub
 Fuse callbacks that redirect all calls to the CernVM-FS shared library.
@@ -742,7 +742,7 @@ changes.
 Based on the read-write interface to CernVM-FS, we create a feed-back
 loop that represents the addition of new software releases to a
 CernVM-FS repository. A repository in base revision :math:`r` is mounted
-in read-write mode on the publisher’s end. Changes are written to the
+in read-write mode on the publisher's end. Changes are written to the
 scratch area and, once published, are re-mounted as repository revision
 :math:`r+1`. In this way, CernVM-FS provides snapshots. In case of
 errors, one can safely resume from a previously committed revision.

--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -1,9 +1,9 @@
 Implementation Notes
 ====================
 
-CernVM-FS has a modular structure and relies on several open source libraries.
-Figure :ref:`below <fig_cvmfsblocks>` shows the internal building blocks of
-CernVM-FS. Most of these libraries are shipped with the CernVM-FS sources and
+CernVM-FS has a modular structure and relies on several open source libraries.
+Figure :ref:`below <fig_cvmfsblocks>` shows the internal building blocks of
+CernVM-FS. Most of these libraries are shipped with the CernVM-FS sources and
 are linked statically in order to facilitate debugging and to keep the system
 dependencies minimal.
 
@@ -20,10 +20,10 @@ dependencies minimal.
 File Catalog
 ------------
 
-A CernVM-FS repository is defined by its *file catalog*. The file
-catalog is an `SQLite database <https://www.sqlite.org>`_ [Allen10]_
+A CernVM-FS repository is defined by its *file catalog*. The file
+catalog is an `SQLite database <https://www.sqlite.org>`_ [Allen10]_
 having a single table that lists files and directories together with
-its metadata. The table layout is shown in the table below:
+its metadata. The table layout is shown in the table below:
 
 .. _tab_catalog:
 
@@ -45,18 +45,18 @@ gid                     Integer
 ====================== ================
 
 In order to save space we do not store absolute paths. Instead we
-store MD5 [Rivest92]_, [Turner11]_ hash values of the absolute path
+store MD5 [Rivest92]_, [Turner11]_ hash values of the absolute path
 names. Symbolic links are kept in the catalog. Symbolic links may
 contain environment variables in the form ``$(VAR_NAME)`` or
 ``$(VAR_NAME:-/default/path)`` that will be dynamically resolved by
-CernVM-FS on access. Hardlinks are emulated by CernVM-FS. The hardlink
+CernVM-FS on access. Hardlinks are emulated by CernVM-FS. The hardlink
 count is stored in the lower 32bit of the hardlinks field, a *hardlink
 group* is stored in the higher 32 bit. If the hardlink group is
 greater than zero, all files with the same hardlink group will get the
-same inode issued by the CernVM-FS Fuse client. The emulated hardlinks
+same inode issued by the CernVM-FS Fuse client. The emulated hardlinks
 work within the same directory, only. The cryptographic content hash
-refers to the zlib-compressed [Deutsch96]_ version of the file. Flags
-indicate the type of an directory entry (see table :ref:`below
+refers to the zlib-compressed [Deutsch96]_ version of the file. Flags
+indicate the type of an directory entry (see table :ref:`below
 <tab_dirent_flags>`).
 
 .. _tab_dirent_flags:
@@ -73,18 +73,18 @@ indicate the type of an directory entry (see table :ref:`below
 A file catalog contains a *time to live* (TTL), stored in seconds. The
 catalog TTL advises clients to check for a new version of the catalog,
 when expired. Checking for a new catalog version takes place with the
-first file system operation on a CernVM-FS volume after the TTL has
+first file system operation on a CernVM-FS volume after the TTL has
 expired. The default TTL is 15 minutes. If a new catalog is available,
-CernVM-FS delays the loading for the period of the CernVM-FS kernel
-cache life time (default: 1 minute). During this drain-out period, the
+CernVM-FS delays the loading for the period of the CernVM-FS kernel
+cache life time (default: 1 minute). During this drain-out period, the
 kernel caching is turned off. The first file system operation on a
-CernVM-FS volume after that additional delay will apply a new file
+CernVM-FS volume after that additional delay will apply a new file
 catalog and kernel caching is turned back on.
 
 Content Hashes
 ~~~~~~~~~~~~~~
 
-CernVM-FS can use SHA-1 [Jones01]_, RIPEMD-160 [Dobbertin96]_ and
+CernVM-FS can use SHA-1 [Jones01]_, RIPEMD-160 [Dobbertin96]_ and
 SHAKE-128 [Bertoni09]_ as cryptographic hash function. The hash function
 can be changed on the Stratum 0 during the lifetime of repositories.
 On a change, new and updated files will use the new cryptographic hash
@@ -100,7 +100,7 @@ Nested Catalogs
 In order to keep catalog sizes reasonable [#]_, repository subtrees may be cut
 and stored as separate *nested catalogs*. There is no limit on the level of
 nesting. A reasonable approach is to store separate software versions as
-separate nested catalogs. The figure :ref:`below <fig_nested>` shows the
+separate nested catalogs. The figure :ref:`below <fig_nested>` shows the
 simplified directory structure which we use for the ATLAS repository.
 
 .. _fig_nested:
@@ -122,7 +122,7 @@ transparently by CernVM-FS. The cryptographic hash of nested catalogs is
 stored in the parent catalog. Therefore, the root catalog fully defines
 an entire repository.
 
-Loading of nested catalogs happens on demand by CernVM-FS on the first
+Loading of nested catalogs happens on demand by CernVM-FS on the first
 attempt to access of anything inside, a user won’t see the difference
 between a single large catalog and several nested catalogs. While this
 usually avoids unnecessary catalogs to be loaded, recursive operations
@@ -131,7 +131,7 @@ like ``find`` can easily bypass this optimization.
 Catalog Statistics
 ~~~~~~~~~~~~~~~~~~
 
-A CernVM-FS file catalog maintains several counters about its contents
+A CernVM-FS file catalog maintains several counters about its contents
 and the contents of all of its nested catalogs. The idea is that the
 catalogs know how many entries there are in their sub catalogs even
 without opening them. This way, one can immediately tell how many
@@ -164,9 +164,9 @@ the subtree this catalog is root of:
 Repository Manifest (.cvmfspublished)
 -------------------------------------
 
-Every CernVM-FS repository contains a repository manifest file that
+Every CernVM-FS repository contains a repository manifest file that
 serves as entry point into the repository’s catalog structure. The
-repository manifest is the first file accessed by the CernVM-FS client
+repository manifest is the first file accessed by the CernVM-FS client
 at mount time and therefore must be accessible via HTTP on the
 repository root URL. It is always called **.cvmfspublished** and
 contains fundamental repository meta data like the root catalog’s
@@ -199,7 +199,7 @@ followed by signature information further described :ref:`here
         [...]
 
 Please refer to
-table below for detailed information about each of the
+table below for detailed information about each of the
 meta data fields.
 
 .. |br| raw:: html
@@ -267,7 +267,7 @@ produced by the X.509 certificate signing procedure in binary form.
 Signature Validation
 ^^^^^^^^^^^^^^^^^^^^
 
-In order to validate repository manifest signatures, CernVM-FS uses a
+In order to validate repository manifest signatures, CernVM-FS uses a
 white-list of valid publisher certificates. The white-list contains the
 cryptographic fingerprints of known publisher certificates and a
 timestamp. A white-list is valid for 30 days. It is signed by a private
@@ -275,25 +275,25 @@ RSA key, which we refer to as *master key*. The public RSA key that
 corresponds to the master key is distributed with the
 ``cvmfs-config-...`` RPMs as well as with every instance of CernVM.
 
-In addition, CernVM-FS checks certificate fingerprints against the local
+In addition, CernVM-FS checks certificate fingerprints against the local
 blacklist /etc/cvmfs/blacklist. The blacklisted fingerprints have to be
 in the same format than the fingerprints on the white-list. The
 blacklist has precedence over the white-list.
 
-As crypto engine, CernVM-FS uses libcrypto from the `OpenSSL project
+As crypto engine, CernVM-FS uses libcrypto from the `OpenSSL project
 <http://www.openssl.org/docs/crypto/crypto.html>`_.
 
 Use of HTTP
 -----------
 
 The particular way of using the HTTP protocol has significant impact on
-the performance and usability of CernVM-FS. If possible, CernVM-FS tries
+the performance and usability of CernVM-FS. If possible, CernVM-FS tries
 to benefit from the HTTP/1.1 features keep-alive and cache-control.
-Internally, CernVM-FS uses the `libcurl library <http://curl.haxx.se/libcurl>`_.
+Internally, CernVM-FS uses the `libcurl library <http://curl.haxx.se/libcurl>`_.
 
 The HTTP behaviour affects a system with cold caches only. As soon as
 all necessary files are cached, there is only network traffic when a
-catalog TTL expires. The CernVM-FS download manager runs as a separate
+catalog TTL expires. The CernVM-FS download manager runs as a separate
 thread that handles download requests asynchronously in parallel.
 Concurrent download requests for the same URL are collapsed into a
 single request.
@@ -301,11 +301,11 @@ single request.
 DoS Protection
 ~~~~~~~~~~~~~~
 
-A subtle denial of service attack (DoS) can occur when CernVM-FS is
+A subtle denial of service attack (DoS) can occur when CernVM-FS is
 successfully able to download a file but fails to store it in the local
 cache. This situation escalates into a DoS when the application using
-CernVM-FS remains in an endless loop and tries to open a file over and
-over again. Such a situation is prevented by CernVM-FS by re-trying with
+CernVM-FS remains in an endless loop and tries to open a file over and
+over again. Such a situation is prevented by CernVM-FS by re-trying with
 an exponential backoff. The backoff is triggered by consequtive filaures
 to cache a downloaded file within 10 seconds.
 
@@ -318,7 +318,7 @@ request-response cycle has a penalty of at least the network round trip
 time. Using plain HTTP/1.0, this results in at least
 :math:`3\cdot\text{round trip time}` additional running time per file
 download for TCP handshake, HTTP GET, and TCP connection finalisation.
-By including the ``Connection: Keep-Alive`` header into HTTP requests,
+By including the ``Connection: Keep-Alive`` header into HTTP requests,
 we advise the HTTP server end to keep the underlying TCP connection
 opened. This way, overhead ideally drops to just round trip time for a
 single HTTP GET. The impact of the keep-alive feature is shown in
@@ -338,15 +338,15 @@ connections anytime, in particular if they run out of resources.
 Cache Control
 ~~~~~~~~~~~~~
 
-In a limited way, CernVM-FS advises intermediate web caches how to
-handle its requests. Therefor it uses the ``Pragma: no-cache`` and the
-``Cache-Control: no-cache`` headers in certain cases. These cache
+In a limited way, CernVM-FS advises intermediate web caches how to
+handle its requests. Therefor it uses the ``Pragma: no-cache`` and the
+``Cache-Control: no-cache`` headers in certain cases. These cache
 control headers apply to both, forward proxies as well as reverse
 proxies. This is not a guarantee that intermediate proxies fetch a fresh
 original copy (though they should).
 
-By including these headers, CernVM-FS tries to not fetch outdated cache
-copies. Only in case CernVM-FS downloads a corrupted file from a proxy
+By including these headers, CernVM-FS tries to not fetch outdated cache
+copies. Only in case CernVM-FS downloads a corrupted file from a proxy
 server, it retries having the HTTP ``no-cache`` header set. This way,
 the corrupted file gets replaced in the proxy server by a fresh copy
 from the backend.
@@ -354,18 +354,18 @@ from the backend.
 Identification Header
 ~~~~~~~~~~~~~~~~~~~~~
 
-CernVM-FS sends a custom header (``X-CVMFS2``) to be identified by the
-web server. If you have set the CernVM GUID, this GUID is also
+CernVM-FS sends a custom header (``X-CVMFS2``) to be identified by the
+web server. If you have set the CernVM GUID, this GUID is also
 transmitted.
 
 Redirects
 ~~~~~~~~~
 
 Normally, the Stratum-1 servers directly respond to HTTP requests so
-CernVM-FS has no need to support HTTP redirect response codes. However,
+CernVM-FS has no need to support HTTP redirect response codes. However,
 there are some high-bandwidth applications where HTTP redirects are used
 to transfer requests to multiple data servers. To enable support for
-redirects in the CernVM-FS client, set ``CVMFS_FOLLOW_REDIRECTS=yes``.
+redirects in the CernVM-FS client, set ``CVMFS_FOLLOW_REDIRECTS=yes``.
 
 Name Resolving
 --------------
@@ -375,28 +375,28 @@ CernVM-FS. Multiple IP addresses for the same proxy name are
 automatically transformed into multiple proxy servers within the same
 load-balance group. So the usual rules for load-balancing and fail-over
 apply to the different servers in a round-robin entry.
-CernVM-FS resolves all the proxy servers at once (and in parallel) at
+CernVM-FS resolves all the proxy servers at once (and in parallel) at
 mount time. From that point on, proxy server names are resolved on
 demand, when a download takes place and the TTL of the active proxy
-expired. CernVM-FS resolves using /etc/host (resp. the file referenced
+expired. CernVM-FS resolves using /etc/host (resp. the file referenced
 in the ``HOST_ALIASES`` environment variable) or, if a host name is not
 resolvable locally, it uses the c-ares resolver. Proxy servers given in
 IP notation remain unchanged.
 
-CernVM-FS uses the TTLs that come from DNS servers. However, there is a
+CernVM-FS uses the TTLs that come from DNS servers. However, there is a
 cutoff at 1 minute minimum TTL and 1 day maximum TTL. Locally resolved
 host names get a TTL of 1 minute. The host alias file is re-read with
 every attempt to resolve a name. Failed attempts to resolve a name
 remain cached for 1 minute, too. If a name has been successfully
 resolved previously, this result stays active until another successful
 attempt is done. If the DNS entries change for a host name,
-CernVM-FS adjust the corresponding load-balance group and picks a new
+CernVM-FS adjust the corresponding load-balance group and picks a new
 server from the group at random.
 
 The name resolving silently ignores errors in individual records. Only
 if no valid IP address is returned at all it counts as an error. IPv4
 addresses have precedence if available. If the ``CVMFS_IPV4_ONLY``
-environment variable is set,\ CernVM-FS does not try to resolve IPv6
+environment variable is set,\ CernVM-FS does not try to resolve IPv6
 records.
 
 The timeout for name resolving is hard-coded to 2 attempts with a
@@ -404,23 +404,23 @@ timeout of 3 seconds each. This is independent from the
 ``CVMFS_TIMEOUT`` and ``CVMFS_TIMEOUT(_DIRECT)`` settings. The effective
 timeout can be a bit longer than 6 seconds because of a backoff.
 
-The name server used by CernVM-FS is looked up only once on start. If
-the name server changes during the life time of a CernVM-FS mount point,
-this change needs to be manually advertised to CernVM-FS using
+The name server used by CernVM-FS is looked up only once on start. If
+the name server changes during the life time of a CernVM-FS mount point,
+this change needs to be manually advertised to CernVM-FS using
 ``cvmfs_talk nameserver set``.
 
 Disk Cache
 ----------
 
-Each running CernVM-FS instance requires a local cache directory. Data
+Each running CernVM-FS instance requires a local cache directory. Data
 are downloaded into a temporary files. Only at the very latest point
 they are renamed into their content-addressable names atomically by
 ``rename()``.
 
-The hard disk cache is managed, CernVM-FS maintains cache size
+The hard disk cache is managed, CernVM-FS maintains cache size
 restrictions and replaces files according to the least recently used
-(LRU) strategy [Panagiotou06]_. In order to keep track of files sizes
-and relative file access times, CernVM-FS sets up another SQLite
+(LRU) strategy [Panagiotou06]_. In order to keep track of files sizes
+and relative file access times, CernVM-FS sets up another SQLite
 database in the cache directory, the *cache catalog*. The cache
 catalog contains a single table; its structure is shown here:
 
@@ -433,8 +433,8 @@ Pinned                            Integer
 File type (chunk or file catalog) Integer
 ================================= =========================
 
-CernVM-FS does not strictly enforce the cache limit. Instead
-CernVM-FS works with two customizable soft limits, the *cache quota* and
+CernVM-FS does not strictly enforce the cache limit. Instead
+CernVM-FS works with two customizable soft limits, the *cache quota* and
 the *cache threshold*. When exceeding the cache quota, files are deleted
 until the overall cache size is less than or equal to the cache
 threshold. The cache threshold is currently hard-wired to half of the
@@ -449,19 +449,19 @@ volume of pinned catalogs exceeds of the overall cache volume.
 The cache catalog can be re-constructed from scratch on mount.
 Re-constructing the cache catalog is necessary when the managed cache is
 used for the first time and every time when “unmanaged” changes occurred
-to the cache directory, when CernVM-FS was terminated unexpectedly.
+to the cache directory, when CernVM-FS was terminated unexpectedly.
 
 In case of an exclusive cache, the cache manager runs as a separate thread of
 the ``cvmfs2`` process. This thread gets notified by the Fuse module whenever
 a file is opened or inserted. Notification is done through a pipe. The shared
 cache uses the very same code, except that the thread becomes a separate
-process (see Figure :ref:`below <fig_sharedcache>`). This cache manager
+process (see Figure :ref:`below <fig_sharedcache>`). This cache manager
 process is not another binary but ``cvmfs2`` forks to itself with special
 arguments, indicating that it is supposed to run as a cache manager. The cache
-manager does not need to be started as a service. The first CernVM-FS instance
+manager does not need to be started as a service. The first CernVM-FS instance
 that uses a shared cache will automatically spawn the cache manager process.
-Subsequent CernVM-FS instances will connect to the pipe of this cache manager.
-Once the last CernVM-FS instance that uses the shared cache is unmounted, the
+Subsequent CernVM-FS instances will connect to the pipe of this cache manager.
+Once the last CernVM-FS instance that uses the shared cache is unmounted, the
 communication pipe is left without any writers and the cache manager
 automatically quits.
 
@@ -473,7 +473,7 @@ automatically quits.
    :width: 70%
 
 
-The CernVM-FS cache supports two classes of files with respect to the
+The CernVM-FS cache supports two classes of files with respect to the
 cache replacement strategy: *normal* files and *volatile* files. The
 sequence numbers of volatile files have bit 63 set. Hence they are
 interpreted as negative numbers and have precedence over normal files
@@ -483,20 +483,20 @@ property of entries in the cache database is lost.
 NFS Maps
 --------
 
-In normal mode, CernVM-FS issues inodes based on the row number of an
+In normal mode, CernVM-FS issues inodes based on the row number of an
 entry in the file catalog. When exported via NFS, this scheme can
-result in inconsistencies because CernVM-FS does not control the cache
+result in inconsistencies because CernVM-FS does not control the cache
 lifetime of NFS clients. A once issued inode can be asked for anytime
 later by a client. To be able to reply to such client queries even
-after reloading catalogs or remounts of CernVM-FS, the CernVM-FS *NFS
+after reloading catalogs or remounts of CernVM-FS, the CernVM-FS *NFS
 maps* implement a persistent store of the path names :math:`\mapsto`
 inode mappings. Storing them on hard disk allows for control of the
-CernVM-FS memory consumption (currently :math:`\approx` 45 MB extra)
+CernVM-FS memory consumption (currently :math:`\approx` 45 MB extra)
 and ensures consistency between remounts of CernVM-FS. The performance
-penalty for doing so is small. CernVM-FS uses `Google’s leveldb
+penalty for doing so is small. CernVM-FS uses `Google’s leveldb
 <https://github.com/google/leveldb>`, a fast, local key value store.
 Reads and writes are only performed when meta-data are looked up in
-SQLite, in which case the SQLite query supposedly dominates the
+SQLite, in which case the SQLite query supposedly dominates the
 running time.
 
 A drawback of the NFS maps is that there is no easy way to account for
@@ -510,14 +510,14 @@ disk.
 Loader
 ------
 
-The CernVM-FS Fuse module comprises a minimal *loader* loader process
+The CernVM-FS Fuse module comprises a minimal *loader* loader process
 (the ``cvmfs2`` binary) and a shared library containing the actual
-Fuse module (``libcvmfs_fuse.so``). This structure makes it possible to
-reload CernVM-FS code and parameters without unmounting the file system.
+Fuse module (``libcvmfs_fuse.so``). This structure makes it possible to
+reload CernVM-FS code and parameters without unmounting the file system.
 Loader and library don’t share any symbols except for two global structs
 ``cvmfs_exports`` and ``loader_exports`` used to call each others
 functions. The loader process opens the Fuse channel and implements stub
-Fuse callbacks that redirect all calls to the CernVM-FS shared library.
+Fuse callbacks that redirect all calls to the CernVM-FS shared library.
 Hotpatch is implemented as unloading and reloading of the shared
 library, while the loader temporarily queues all file system calls
 in-between. Among file system calls, the Fuse module has to keep very
@@ -529,7 +529,7 @@ is saved and restored.
 File System Interface
 ---------------------
 
-CernVM-FS implements the following read-only file system call-backs.
+CernVM-FS implements the following read-only file system call-backs.
 
 mount
 ~~~~~
@@ -539,11 +539,11 @@ On mount, the file catalog has to be loaded. First, the file catalog
 on successful validation of the signature. In order to validate the
 signature, the certificate and the white-list are downloaded in addition
 if not found in cache. If the download fails for whatever reason,
-CernVM-FS tries to load a local file catalog copy. As long as all
-requested files are in the disk cache as well, CernVM-FS continues to
+CernVM-FS tries to load a local file catalog copy. As long as all
+requested files are in the disk cache as well, CernVM-FS continues to
 operate even without network access (*offline mode*). If there is no
 local copy of the manifest or the downloaded manifest and the cache copy
-differ, CernVM-FS downloads a fresh copy of the file catalog.
+differ, CernVM-FS downloads a fresh copy of the file catalog.
 
 getattr and lookup
 ~~~~~~~~~~~~~~~~~~
@@ -551,8 +551,8 @@ getattr and lookup
 Requests for file attributes are entirely served from the mounted
 catalogs, there is no network traffic involved. This function is called
 as pre-requisite to other file system operations and therefore the most
-frequently called Fuse callback. In order to minimize relatively
-expensive SQLite queries, CernVM-FS uses a hash table to store negative
+frequently called Fuse callback. In order to minimize relatively
+expensive SQLite queries, CernVM-FS uses a hash table to store negative
 and positive query results. The default size of for this memory cache is
 determined according to benchmarks with LHC experiment software.
 
@@ -570,9 +570,9 @@ readlink
 ~~~~~~~~
 
 A symbolic link is served from the file catalog. As a special extension,
-CernVM-FS detects environment variables in symlink strings written as
+CernVM-FS detects environment variables in symlink strings written as
 ``$(VARIABLE)`` or ``$(VARIABLE:-/default/path)``. These variables are
-expanded by CernVM-FS dynamically on access (in the context of the
+expanded by CernVM-FS dynamically on access (in the context of the
 ``cvmfs2`` process). This way, a single symlink can point to different
 locations depending on the environment. This is helpful, for instance,
 to dynamically select software package versions residing in different
@@ -590,15 +590,15 @@ open / read
 ~~~~~~~~~~~
 
 The ``open()`` call has to provide a file descriptor for a given path
-name. In CernVM-FS file requests are always served from the disk cache.
-The Fuse file handle is a file descriptor valid in the context of the
-CernVM-FS process. It points into the disk cache directory. Read
+name. In CernVM-FS file requests are always served from the disk cache.
+The Fuse file handle is a file descriptor valid in the context of the
+CernVM-FS process. It points into the disk cache directory. Read
 requests are translated into the ``pread()`` system call.
 
 getxattr
 ~~~~~~~~
 
-CernVM-FS uses extended attributes to display additional repository
+CernVM-FS uses extended attributes to display additional repository
 information. There are two supported attributes:
 
 **expires**
@@ -646,7 +646,7 @@ information. There are two supported attributes:
     Shows the overall number of ``open()`` calls since mounting.
 
 **pid**
-    Shows the process id of the CernVM-FS Fuse process.
+    Shows the process id of the CernVM-FS Fuse process.
 
 **proxy**
     Shows the currently active HTTP proxy.
@@ -684,7 +684,7 @@ information. There are two supported attributes:
     clients.
 
 **version**
-    Shows the version of the loaded CernVM-FS binary.
+    Shows the version of the loaded CernVM-FS binary.
 
 Extended attributes can be queried using the ``attr`` command. For
 instance, ``attr -g hash /cvmfs/atlas.cern.ch/ChangeLog`` returns the
@@ -700,7 +700,7 @@ This might be installation of a new release or a patch for an existing
 release. But, of course, each time only a small portion of the
 repository is touched, say out of . In order not to re-process an entire
 repository on every update, we create a read-write file system interface
-to a CernVM-FS repository where all changes are written into a distinct
+to a CernVM-FS repository where all changes are written into a distinct
 scratch area.
 
 Read-write Interface using a Union File System
@@ -717,14 +717,14 @@ changes are in fact written to the read-write branch.
 
 Preserving POSIX semantics in union file systems is non-trivial; the
 first fully functional implementation has been presented by Wright et
-al. [Wright04]_. By now, union file systems are well established for
+al. [Wright04]_. By now, union file systems are well established for
 “Live CD” builders, which use a RAM disk overlay on top of the read-
 only system partition in order to provide the illusion of a fully
-read-writable system. CernVM-FS supports both aufs and OverlayFS
+read-writable system. CernVM-FS supports both aufs and OverlayFS
 union file systems.
 
 Union file systems can be used to track changes on CernVM-FS repositories
-(Figure :ref:`below <fig_overlay>`). In this case, the read-only file system
+(Figure :ref:`below <fig_overlay>`). In this case, the read-only file system
 interface of CernVM-FS is used in conjunction with a writable scratch area for
 changes.
 

--- a/cpt-overview.rst
+++ b/cpt-overview.rst
@@ -10,7 +10,7 @@ distribution of files, CernVM-FS uses a standard HTTP [BernersLee96]_
 caches, including commercial content delivery networks. CernVM-FS
 ensures data authenticity and integrity over these possibly untrusted
 caches and connections. The CernVM-FS software comprises client-side
-software to mount “CernVM-FS repositories” (similar to AFS volumes) as
+software to mount "CernVM-FS repositories" (similar to AFS volumes) as
 well as a server-side toolkit to create such distributable CernVM-FS
 repositories.
 

--- a/cpt-overview.rst
+++ b/cpt-overview.rst
@@ -1,32 +1,32 @@
 Overview
 ========
 
-The CernVM File System (CernVM-FS) is a read-only file system designed
+The CernVM File System (CernVM-FS) is a read-only file system designed
 to deliver scientific software onto virtual machines and physical
 worker nodes in a fast, scalable, and reliable way. Files and file
 metadata are downloaded on demand and aggressively cached. For the
-distribution of files, CernVM-FS uses a standard HTTP [BernersLee96]_
+distribution of files, CernVM-FS uses a standard HTTP [BernersLee96]_
 [Fielding99]_ transport, which allows exploitation of a variety of web
 caches, including commercial content delivery networks. CernVM-FS
 ensures data authenticity and integrity over these possibly untrusted
-caches and connections. The CernVM-FS software comprises client-side
-software to mount “CernVM-FS repositories” (similar to AFS volumes) as
+caches and connections. The CernVM-FS software comprises client-side
+software to mount “CernVM-FS repositories” (similar to AFS volumes) as
 well as a server-side toolkit to create such distributable CernVM-FS
 repositories.
 
 .. figure:: _static/concept-generic.svg
    :alt: General overview over CernVM-File System's Architecture
 
-   A CernVM-FS client provides a virtual file system that loads data
+   A CernVM-FS client provides a virtual file system that loads data
    only on access. In this example, all releases of a sofware package
    (such as an HEP experiment framework) are hosted as a
-   CernVM-FS repository on a web server.
+   CernVM-FS repository on a web server.
 
-The first implementation of CernVM-FS was based on grow-fs
+The first implementation of CernVM-FS was based on grow-fs
 [Compostella10]_ [Thain05]_, which was originally provided as one of
 the private file system options available in Parrot. Ever since the
 design evolved and diverged, taking into account the works on HTTP-
-Fuse [Suzaki06]_ and content-delivery networks [Freedman03]_
+Fuse [Suzaki06]_ and content-delivery networks [Freedman03]_
 [Nygren10]_ [Tolia03]_. Its current implementation provides the
 following key features:
 
@@ -69,22 +69,22 @@ following key features:
 -  Possibility to use S3 compatible storage instead of a file system as
    repository storage
 
-In contrast to general purpose network file systems such as nfs or afs,
-CernVM-FS is particularly crafted for fast and scalable software
+In contrast to general purpose network file systems such as nfs or afs,
+CernVM-FS is particularly crafted for fast and scalable software
 distribution. Running and compiling software is a use case general
 purpose distributed file systems are not optimized for. In contrast to
 virtual machine images or Docker images, software installed in
-CernVM-FS does not need to be further packaged. Instead it is
+CernVM-FS does not need to be further packaged. Instead it is
 distributed and versioned file-by-file. In order to create and update a
-CernVM-FS repository, a distinguished machine, the so-called *Release
+CernVM-FS repository, a distinguished machine, the so-called *Release
 Manager Machine*, is used. On such a release manager machine, a
-CernVM-FS repository is mounted in read/write mode by means of a union
-file system [Wright04]_. The union file system overlays the CernVM-FS read-only
-mount point by a writable scratch area. The CernVM-FS server tool kit
+CernVM-FS repository is mounted in read/write mode by means of a union
+file system [Wright04]_. The union file system overlays the CernVM-FS read-only
+mount point by a writable scratch area. The CernVM-FS server tool kit
 merges changes written to the scratch area into the
-CernVM-FS repository. Merging and publishing changes can be triggered at
+CernVM-FS repository. Merging and publishing changes can be triggered at
 user-defined points in time; it is an atomic operation. As such, a
-CernVM-FS repository is similar to a repository in the sense of a
+CernVM-FS repository is similar to a repository in the sense of a
 versioning system.
 
 On the client, only data and metadata of the software releases that are
@@ -95,8 +95,8 @@ actually used are downloaded and cached.
    :figwidth: 550
    :align: center
 
-   Opening a file on CernVM-FS. CernVM-FS resolves the name by means of
-   an SQLite catalog. Downloaded files are verified against the
+   Opening a file on CernVM-FS. CernVM-FS resolves the name by means of
+   an SQLite catalog. Downloaded files are verified against the
    cryptographic hash of the corresponding catalog entry. The ``read()``
    and the ``stat()`` system call can be entirely served from the
    in-kernel file system buffers.

--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -3,8 +3,8 @@ Getting Started
 
 This section describes how to install the CernVM-FS client. The
 CernVM-FS client is supported on x86, x86\_64, and ARMv7 architectures
-running Scientific Linux 4–7, Ubuntu \ :math:`\geq12.04`, SLES 11 and
-openSuSE 13.1, Fedora 19–21, or Mac OS X \ :math:`\geq 10.8`.
+running Scientific Linux 4-7, Ubuntu \ :math:`\geq12.04`, SLES 11 and
+openSuSE 13.1, Fedora 19-21, or Mac OS X \ :math:`\geq 10.8`.
 
 Getting the Software
 --------------------

--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -155,7 +155,7 @@ In order to check for common misconfigurations in the base setup, run
 
 CernVM-FS gathers its configuration parameter from various configuration
 files that can overwrite each others settings (default configuration,
-domain specific configuration, local setup, …). To show the effective
+domain specific configuration, local setup, ...). To show the effective
 configuration for *repository*.cern.ch, run
 
 ::

--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -1,28 +1,28 @@
 Getting Started
 ===============
 
-This section describes how to install the CernVM-FS client. The
-CernVM-FS client is supported on x86, x86\_64, and ARMv7 architectures
-running Scientific Linux 4–7, Ubuntu \ :math:`\geq12.04`, SLES 11 and
-openSuSE 13.1, Fedora 19–21, or Mac OS X \ :math:`\geq 10.8`.
+This section describes how to install the CernVM-FS client. The
+CernVM-FS client is supported on x86, x86\_64, and ARMv7 architectures
+running Scientific Linux 4–7, Ubuntu \ :math:`\geq12.04`, SLES 11 and
+openSuSE 13.1, Fedora 19–21, or Mac OS X \ :math:`\geq 10.8`.
 
 Getting the Software
 --------------------
 
-The CernVM-FS source code and binary packages are available `on our
+The CernVM-FS source code and binary packages are available `on our
 website <https://cernvm.cern.ch/portal/filesystem/downloads>`_. Binary
 packages are produced for rpm, dpkg, and Mac OS X (.pkg). yum
 repositories for 64 bit and 32 bit Scientific Linux 5 and 6 and 64 bit
 Scientific Linux 7 are available as a `yum repository
 <http://cvmrepo.web.cern.ch/cvmrepo/yum>`_. The ``cvmfs-release``
-packages can be used to add a these yum repositories to the local yum
+packages can be used to add a these yum repositories to the local yum
 installation. The ``cvmfs-release`` packages are available on `our
 download page <https://cernvm.cern.ch/portal/filesystem/downloads>`_.
 
-The CernVM-FS client is not relocatable and needs to be installed under
-/usr. On Intel architectures, it needs a gcc :math:`\geq 4.2` compiler,
-on ARMv7 a gcc :math:`\geq 4.7` compiler. In order to compile and
-install from sources, use the following cmake command:
+The CernVM-FS client is not relocatable and needs to be installed under
+/usr. On Intel architectures, it needs a gcc :math:`\geq 4.2` compiler,
+on ARMv7 a gcc :math:`\geq 4.7` compiler. In order to compile and
+install from sources, use the following cmake command:
 
 ::
 
@@ -39,14 +39,14 @@ Linux
 To install, proceed according to the following steps:
 
 **Step 1**
-    Install the CernVM-FS packages. With yum, run
+    Install the CernVM-FS packages. With yum, run
 
     ::
 
           yum install cvmfs cvmfs-config-default
 
     If yum does not show the latest packages, clean the yum cache by
-    ``yum clean all``. Packages can be also installed with rpm instead
+    ``yum clean all``. Packages can be also installed with rpm instead
     with the command ``rpm -vi``. On Ubuntu, use ``dpkg -i`` on the
     cvmfs and cvmfs-config-default .deb packages.
 
@@ -77,23 +77,23 @@ To install, proceed according to the following steps:
 
     For the syntax of more complex HTTP proxy settings, see
     :ref:`sct_network`. Make sure your local proxy servers allow access to all
-    the Stratum 1 web servers (more on :ref:`proxy configuration here <cpt_squid>`). For Cern
+    the Stratum 1 web servers (more on :ref:`proxy configuration here <cpt_squid>`). For Cern
     repositories, the Stratum 1 web servers are listed in
     /etc/cvmfs/domain.d/cern.ch.conf.
 
 **Step 5**
-    Check if CernVM-FS mounts the specified repositories by
+    Check if CernVM-FS mounts the specified repositories by
     ``cvmfs_config probe``.
 
 Mac OS X
 ~~~~~~~~
 
-On Mac OS X, CernVM-FS is based on `OSXFuse <http://osxfuse.github.io>`_.
+On Mac OS X, CernVM-FS is based on `OSXFuse <http://osxfuse.github.io>`_.
 It is not integrated with autofs. In order to install, proceed according
 to the following steps:
 
 **Step 1**
-    Install the CernVM-FS package by opening the .pkg file.
+    Install the CernVM-FS package by opening the .pkg file.
 
 **Step 2**
     Create /etc/cvmfs/default.local and open the file for editing.
@@ -126,16 +126,16 @@ to the following steps:
 Usage
 -----
 
-The CernVM-FS repositories are located under /cvmfs. Each repository is
+The CernVM-FS repositories are located under /cvmfs. Each repository is
 identified by a *fully qualified repository name*. The fully qualified
 repository name consists of a repository identifier and a domain name,
-similar to DNS records [Mockapetris87]_. The domain part of the fully qualified
+similar to DNS records [Mockapetris87]_. The domain part of the fully qualified
 repository name indicates the location of repository creation and
 maintenance. For the ATLAS experiment software, for instance, the fully
 qualified repository name is atlas.cern.ch although the hosting web
 servers are spread around the world.
 
-Mounting and un-mounting of the CernVM-FS is controlled by autofs and
+Mounting and un-mounting of the CernVM-FS is controlled by autofs and
 automount. That is, starting from the base directory /cvmfs different
 repositories are mounted automatically just by accessing them. For
 instance, running the command ``ls /cvmfs/atlas.cern.ch`` will mount the
@@ -153,7 +153,7 @@ In order to check for common misconfigurations in the base setup, run
 
       cvmfs_config chksetup
 
-CernVM-FS gathers its configuration parameter from various configuration
+CernVM-FS gathers its configuration parameter from various configuration
 files that can overwrite each others settings (default configuration,
 domain specific configuration, local setup, …). To show the effective
 configuration for *repository*.cern.ch, run

--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -112,7 +112,7 @@ to the following steps:
 
           CVMFS_HTTP_PROXY="http://myproxy1:port|http://myproxy2:port"
 
-    If you’re unsure about the proxy names, set
+    If you're unsure about the proxy names, set
     ``CVMFS_HTTP_PROXY=DIRECT``.
 
 **Step 4**
@@ -184,7 +184,7 @@ original error served from the file system buffers by
 
       service autofs restart
 
-In case you need additional assistance, please don’t hesitate to contact
+In case you need additional assistance, please don't hesitate to contact
 us at `cernvm.support@cern.ch <cernvm.support@cern.ch>`__. Together with
 the problem description, please send the system information tarball
 created by ``cvmfs_config bugreport``.

--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -1,13 +1,13 @@
 .. _cpt_replica:
 
-Setting up a Replica Server (Stratum 1)
+Setting up a Replica Server (Stratum 1)
 =======================================
 
-While a CernVM-FS Stratum 0 repository server is able to serve clients
-directly, a large number of clients is better be served by a set of Stratum 1
-replica servers. Multiple Stratum 1 servers improve the reliability, reduce
+While a CernVM-FS Stratum 0 repository server is able to serve clients
+directly, a large number of clients is better be served by a set of Stratum 1
+replica servers. Multiple Stratum 1 servers improve the reliability, reduce
 the load, and protect the Stratum 0 master copy of the repository from direct
-accesses. Stratum 0 server, Stratum 1 servers and the site-local proxy servers
+accesses. Stratum 0 server, Stratum 1 servers and the site-local proxy servers
 can be seen as content distribution network. The :ref:`figure below
 <fig_stratum1>` shows the situation for the repositories hosted in the
 cern.ch domain.
@@ -24,32 +24,32 @@ cern.ch domain.
    mirror servers. A distributed hierarchy of proxy servers fetches content
    from the closest public mirror server.
 
-A Stratum 1 server is a standard web server that uses the
-CernVM-FS server toolkit to create and maintain a mirror of a
-CernVM-FS repository served by a Stratum 0 server. To this end, the
+A Stratum 1 server is a standard web server that uses the
+CernVM-FS server toolkit to create and maintain a mirror of a
+CernVM-FS repository served by a Stratum 0 server. To this end, the
 ``cvmfs_server`` utility provides the ``add-replica`` command. This
-command will register the Stratum 0 URL and prepare the local web
+command will register the Stratum 0 URL and prepare the local web
 server. Periodical synchronization has to be scheduled, for instance
 with ``cron``, using the ``cvmfs_server snapshot`` command. The
 advantage over general purpose mirroring tools such as rSync is that all
-CernVM-FS file integrity verifications mechanisms from the Fuse client
-are reused. Additionally, by the aid of the CernVM-FS file catalogs, the
+CernVM-FS file integrity verifications mechanisms from the Fuse client
+are reused. Additionally, by the aid of the CernVM-FS file catalogs, the
 ``cvmfs_server`` utility knows beforehand (without remote listing) which
 files to transfer.
 
 In order to prevent accidental synchronization from a repository, the
-Stratum 0 repository maintainer has to create a
+Stratum 0 repository maintainer has to create a
 ``.cvmfs_master_replica`` file in the HTTP root directory. This file is
 created by default when a new repository is created. Note that
-replication can thrash caches that might exist between Stratum 1 and
-Stratum 0. A direct connection is therefore preferable.
+replication can thrash caches that might exist between Stratum 1 and
+Stratum 0. A direct connection is therefore preferable.
 
 Recommended Setup
 -----------------
 
 The vast majority of HTTP requests will be served by the site’s local
 proxy servers. Being a publicly available service, however, we recommend
-to install a Squid frontend in front of the Stratum 1 web server.
+to install a Squid frontend in front of the Stratum 1 web server.
 
 We suggest the following key parameters:
 
@@ -66,13 +66,13 @@ We suggest the following key parameters:
     should be close to the storage in terms of latency.
 
 **Squid frontend**
-    Squid should be used as a frontend to Apache, configured as a
+    Squid should be used as a frontend to Apache, configured as a
     reverse proxy. It is recommended to run it on the same machine as
     Apache to reduce the number of points of failure. Alternatively,
-    separate Squid server machines may be configured in load-balance
+    separate Squid server machines may be configured in load-balance
     mode forwarding to the Apache server, but note that if any of them
     are down the entire service will be considered down by
-    CernVM-FS clients. The Squid frontend should listen on ports 80 and
+    CernVM-FS clients. The Squid frontend should listen on ports 80 and
     8000. The more RAM that the operating system can use for file system
     caching, the better.
 
@@ -85,9 +85,9 @@ We suggest the following key parameters:
 Squid Configuration
 -------------------
 
-The Squid configuration differs from the site-local Squids because the
-Stratum 1 Squid servers are transparent to the clients (*reverse
-proxy*). As the expiry rules are set by the web server, Squid cache
+The Squid configuration differs from the site-local Squids because the
+Stratum 1 Squid servers are transparent to the clients (*reverse
+proxy*). As the expiry rules are set by the web server, Squid cache
 expiry rules remain unchanged.
 
 The following lines should appear accordingly in /etc/squid/squid.conf:
@@ -131,14 +131,14 @@ Monitoring
 The ``cvmfs_server`` utility reports status and problems to ``stdout``
 and ``stderr``.
 
-For the web server infrastructure, we recommend standard Nagios HTTP
+For the web server infrastructure, we recommend standard Nagios HTTP
 checks. They should be configured with the URL
 http://$replica-server/cvmfs/$repository_name/.cvmfspublished. This file
 can also be used to monitor if the same repository revision is served by
-the Stratum 0 server and all the Stratum 1 servers. In order to tune the
+the Stratum 0 server and all the Stratum 1 servers. In order to tune the
 hardware and cache sizes, keep an eye on the Squid server’s CPU and I/O
 load.
 
 Keep an eye on HTTP 404 errors. For normal CernVM-FS traffic, such
-failures should not occur. Traffic from CernVM-FS clients is marked by
+failures should not occur. Traffic from CernVM-FS clients is marked by
 an ``X-CVMFS2`` header.

--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -47,7 +47,7 @@ Stratum 0. A direct connection is therefore preferable.
 Recommended Setup
 -----------------
 
-The vast majority of HTTP requests will be served by the site’s local
+The vast majority of HTTP requests will be served by the site's local
 proxy servers. Being a publicly available service, however, we recommend
 to install a Squid frontend in front of the Stratum 1 web server.
 
@@ -136,7 +136,7 @@ checks. They should be configured with the URL
 http://$replica-server/cvmfs/$repository_name/.cvmfspublished. This file
 can also be used to monitor if the same repository revision is served by
 the Stratum 0 server and all the Stratum 1 servers. In order to tune the
-hardware and cache sizes, keep an eye on the Squid server’s CPU and I/O
+hardware and cache sizes, keep an eye on the Squid server's CPU and I/O
 load.
 
 Keep an eye on HTTP 404 errors. For normal CernVM-FS traffic, such

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -1,29 +1,29 @@
-Creating a Repository (Stratum 0)
+Creating a Repository (Stratum 0)
 =================================
 
-CernVM-FS is a file system with a single source of (new) data. This
+CernVM-FS is a file system with a single source of (new) data. This
 single source, the repository *Stratum 0*, is maintained by a dedicated
 *release manager machine* or *installation box*. A read-writable copy of
 the repository is accessible on the release manager machine. The
-CernVM-FS server tool kit is used to *publish* the current state of the
+CernVM-FS server tool kit is used to *publish* the current state of the
 repository on the release manager machine. Publishing is an atomic
 operation.
 
-All data stored in CernVM-FS have to be converted into a
-CernVM-FS *repository* during the process of publishing. The
-CernVM-FS repository is a form of content-addressable storage.
+All data stored in CernVM-FS have to be converted into a
+CernVM-FS *repository* during the process of publishing. The
+CernVM-FS repository is a form of content-addressable storage.
 Conversion includes creating the file catalog(s), compressing new and
 updated files and calculating content hashes. Storing the data in a
 content-addressable format results in automatic file de-duplication. It
 furthermore simplifies data verification and it allows for file system
 snapshots.
 
-In order to provide a writable CernVM-FS repository, CernVM-FS uses a union
-file system that combines a read-only CernVM-FS mount point with a writable
-scratch area [Wright04]_. :ref:`This figure below <fig_updateprocess>` outlines
+In order to provide a writable CernVM-FS repository, CernVM-FS uses a union
+file system that combines a read-only CernVM-FS mount point with a writable
+scratch area [Wright04]_. :ref:`This figure below <fig_updateprocess>` outlines
 the process of publishing a repository.
 
-CernVM-FS Server Quick-Start Guide
+CernVM-FS Server Quick-Start Guide
 ----------------------------------
 
 System Requirements
@@ -42,7 +42,7 @@ System Requirements
    -  Scientific Linux 5 (64 bit)
 
    -  Scientific Linux 6 (64 bit - with custom AUFS enabled kernel -
-      Appendix ":ref:`apx_rpms`")
+      Appendix ":ref:`apx_rpms`")
 
    -  Fedora 22 and above (with kernel :math:`\ge` 4.2.x)
 
@@ -89,22 +89,22 @@ Backup Policy
 
    -  For local storage: ``/srv/cvmfs``
 
-   -  Stratum 1s can serve as last-ressort backup of repository content
+   -  Stratum 1s can serve as last-ressort backup of repository content
 
 .. _sct_customkernelinstall:
 
 Installing the AUFS-enabled Kernel on Scientific Linux 6
 --------------------------------------------------------
 
-CernVM-FS uses the union file-system `aufs
+CernVM-FS uses the union file-system `aufs
 <http://aufs.sourceforge.net>`_ to efficiently determine file-system
 tree updates while publishing repository transactions on the server
-(see Figure :ref:`below <fig_updateprocess>`). Note that this is
-*only* required on a CernVM-FS server and *not* on the client
+(see Figure :ref:`below <fig_updateprocess>`). Note that this is
+*only* required on a CernVM-FS server and *not* on the client
 machines.
 
 | We provide customised kernel packages for Scientific Linux 6 (see
-  Appendix ":ref:`apx_rpms`") and keep them up-to-date with upstream kernel
+  Appendix ":ref:`apx_rpms`") and keep them up-to-date with upstream kernel
   updates. The kernel RPMs are published in the ``cernvm-kernel`` yum
   repository.
 | Please follow these steps to install the provided customised kernel:
@@ -117,17 +117,17 @@ machines.
    | This adds the CernVM yum repositories to your machine’s
      configuration.
 
-#. | Install the aufs enabled kernel from ``cernvm-kernel``:
+#. | Install the aufs enabled kernel from ``cernvm-kernel``:
    | ``yum --disablerepo=* --enablerepo=cernvm-kernel install kernel``
 
-#. | Install the aufs user utilities:
+#. | Install the aufs user utilities:
    | ``yum --enablerepo=cernvm-kernel install aufs2-util``
 
 #. Reboot the machine
 
 Once a new kernel version is released ``yum update`` will *not* pick the
 upstream version but it will wait until the patched kernel with
-aufs support is published by the CernVM team. We always try to follow
+aufs support is published by the CernVM team. We always try to follow
 the kernel updates as quickly as possible.
 
 Publishing a new Repository Revision
@@ -138,10 +138,10 @@ Publishing a new Repository Revision
 .. figure:: _static/update_process.svg
    :alt: CernVM-FS server schematic update overview
 
-   Updating a mounted CernVM-FS repository by overlaying it with a
-   copy-on-write union file system volume. Any changes will be
+   Updating a mounted CernVM-FS repository by overlaying it with a
+   copy-on-write union file system volume. Any changes will be
    accumulated in a writable volume (yellow) and can be synchronized
-   into the CernVM-FS repository afterwards. The file catalog contains
+   into the CernVM-FS repository afterwards. The file catalog contains
    the directory structure as well as file metadata, symbolic links, and
    secure hash keys of regular files. Regular files are compressed and
    renamed to their cryptographic content hash before copied into the
@@ -151,24 +151,24 @@ Since the repositories may contain many file system objects (i.e. ATLAS
 contains :math:`70 * 10^6` file system objects -- February 2016), we
 cannot afford to generate an entire repository from scratch for every
 update. Instead, we add a writable file system layer on top of a mounted
-read-only CernVM-FS repository using a union file system.
-This renders a read-only CernVM-FS mount point writable to the user,
+read-only CernVM-FS repository using a union file system.
+This renders a read-only CernVM-FS mount point writable to the user,
 while all performed changes are stored in a special writable scratch
 area managed by the union file system. A similar approach is used by Linux
 Live Distributions that are shipped on read-only media, but allow *virtual*
 editing of files where changes are stored on a RAM disk.
 
-If a file in the CernVM-FS repository gets changed, the union file system
+If a file in the CernVM-FS repository gets changed, the union file system
 first copies it to the writable volume and applies any changes to this copy
 (copy-on-write semantics). Also newly created files or directories will be
 stored in the writable volume. Additionally the union file system creates
 special hidden files (called *white-outs*) to keep track of file
-deletions in the CernVM-FS repository.
+deletions in the CernVM-FS repository.
 
 Eventually, all changes applied to the repository are stored in this
-scratch area and can be merged into the actual CernVM-FS repository by a
+scratch area and can be merged into the actual CernVM-FS repository by a
 subsequent synchronization step. Up until the actual synchronization
-step takes place, no changes are applied to the CernVM-FS repository.
+step takes place, no changes are applied to the CernVM-FS repository.
 Therefore, any unsuccessful updates to a repository can be rolled back
 by simply clearing the writable file system layer of the union file system.
 
@@ -178,11 +178,11 @@ Requirements for a new Repository
 ---------------------------------
 
 In order to create a repository, the server and client part of
-CernVM-FS must be installed on the release manager machine. Furthermore
+CernVM-FS must be installed on the release manager machine. Furthermore
 you will need a kernel containing a union file system implementation as
 well as a running ``Apache2`` web server. Currently we support Scientific
 Linux 6, Ubuntu 12.04+ and Fedora 22+ distributions. Please note, that
-Scientific Linux 6 *does not* ship with an aufs enabled kernel, therefore
+Scientific Linux 6 *does not* ship with an aufs enabled kernel, therefore
 we provide a compatible patched kernel as RPMs (see
 :ref:`sct_customkernelinstall` for details).
 
@@ -201,15 +201,15 @@ certain software distributions into a CernVM-FS repository.
 
 .. _sct_serveranatomy:
 
-Notable CernVM-FS Server Locations and Files
+Notable CernVM-FS Server Locations and Files
 --------------------------------------------
 
-There are a number of possible customisations in the CernVM-FS server
+There are a number of possible customisations in the CernVM-FS server
 installation. The following table provides an overview of important
 configuration files and intrinsical paths together with some
 customisation hints. For an exhaustive description of the
-CernVM-FS server infrastructure please consult
-Appendix ":ref:`apx_serverinfra`".
+CernVM-FS server infrastructure please consult
+Appendix ":ref:`apx_serverinfra`".
 
 ======================================== =======================================
 **File Path**                            **Description**
@@ -256,10 +256,10 @@ Appendix ":ref:`apx_serverinfra`".
 
 .. _sct_repocreation_update:
 
-CernVM-FS Repository Creation and Updating
+CernVM-FS Repository Creation and Updating
 ------------------------------------------
 
-The CernVM-FS server tool kit provides the ``cvmfs_server`` utility in
+The CernVM-FS server tool kit provides the ``cvmfs_server`` utility in
 order to perform all operations related to repository creation,
 updating, deletion, replication and inspection. Without any parameters
 it prints a short documentation of its commands.
@@ -277,7 +277,7 @@ A new repository is created by ``cvmfs_server mkfs``:
 
 The utility will ask for a user that should act as the owner of the
 repository and afterwards create all the infrastructure for the new
-CernVM-FS repository. Additionally it will create a reasonable default
+CernVM-FS repository. Additionally it will create a reasonable default
 configuration and generate a new release manager certificate and
 software signing key. The public key in
 ``/etc/cvmfs/keys/my.repo.name.pub`` needs to be distributed to all
@@ -304,7 +304,7 @@ Repositories can be flagged as containing *volatile* files using the
 
       cvmfs_server mkfs -v my.repo.name
 
-When CernVM-FS clients perform a cache cleanup, they treat files from
+When CernVM-FS clients perform a cache cleanup, they treat files from
 volatile repositories with priority. Such volatile repositories can be
 useful, for instance, for experiment conditions data.
 
@@ -313,7 +313,7 @@ useful, for instance, for experiment conditions data.
 S3 Compatible Storage Systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CernVM-FS can store files directly to S3 compatible storage systems,
+CernVM-FS can store files directly to S3 compatible storage systems,
 such as Amazon S3, Huawei UDS and OpenStack SWIFT. The S3 storage
 settings are given as parameters to ``cvmfs_server mkfs`` or
 ``cvmfs_server add-replica``:
@@ -361,9 +361,9 @@ created beforehand.
 
 In addition, if the S3 backend is configured to use multiple accounts or
 buckets, a proxy server is needed to map HTTP requests to correct
-buckets. This mapping is needed because CernVM-FS does not support
+buckets. This mapping is needed because CernVM-FS does not support
 buckets but assumes that all files are stored in a flat namespace. The
-recommendation is to use a Squid proxy server (version
+recommendation is to use a Squid proxy server (version
 :math:`\geq 3.1.10`). The squid.conf can look like this:
 
 ::
@@ -375,7 +375,7 @@ recommendation is to use a Squid proxy server (version
     cache deny all
 
 The bucket mapping logic is implemented in ``s3_squid_rewrite.py`` file.
-This script is not provided by CernVM-FS but needs to be written by the
+This script is not provided by CernVM-FS but needs to be written by the
 repository owner (the CernVM-FS Git repository `contains an example
 <https://github.com/cvmfs/cvmfs/blob/devel/add-ons/s3rewrite.py>`_). The script
 needs to read requests from stdin and write mapped URLs to stdout, for instance:
@@ -394,7 +394,7 @@ Typically a repository publisher does the following steps in order to
 create a new revision of a repository:
 
 #. Run ``cvmfs_server transaction`` to switch to a copy-on-write enabled
-   CernVM-FS volume
+   CernVM-FS volume
 
 #. Make the necessary changes to the repository, add new directories,
    patch certain binaries, …
@@ -409,7 +409,7 @@ create a new revision of a repository:
    -  Run ``cvmfs_server abort`` to clear all changes and start over
       again
 
-CernVM-FS supports having more than one repository on a single server
+CernVM-FS supports having more than one repository on a single server
 machine. In case of a multi-repository host, the target repository of a
 command needs to be given as a parameter when running the
 ``cvmfs_server`` utility. The ``cvmfs_server resign`` command should run
@@ -421,13 +421,13 @@ would migrate all present repositories ending with ``.cern.ch``.
 Repository Import
 ~~~~~~~~~~~~~~~~~
 
-The CernVM-FS server tools support the import of a CernVM-FS file storage
+The CernVM-FS server tools support the import of a CernVM-FS file storage
 together with its corresponding signing keychain. The import functionality is
 useful to bootstrap a release manager machine for a given file storage.
 
 ``cvmfs_server import`` works similar to ``cvmfs_server mkfs`` (described in
 :ref:`sct_repocreation`) except it uses the provided data storage instead of
-creating a fresh (and empty) storage. In case of a CernVM-FS 2.0 file storage
+creating a fresh (and empty) storage. In case of a CernVM-FS 2.0 file storage
 ``cvmfs_server import`` also takes care of the file catalog migration into the
 latest catalog schema (see :ref:`sct_legacyrepoimport` for details).
 
@@ -450,25 +450,25 @@ description of the repository signature mechanics.
 Legacy Repository Import
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-We strongly recommend to install CernVM-FS 2.1 on a fresh or at least a
-properly cleaned machine without any traces of the CernVM-FS 2.0
-installation before installing CernVM-FS 2.1 server tools.
+We strongly recommend to install CernVM-FS 2.1 on a fresh or at least a
+properly cleaned machine without any traces of the CernVM-FS 2.0
+installation before installing CernVM-FS 2.1 server tools.
 
-The command ``cvmfs_server import`` requires the full CernVM-FS 2.0 data
+The command ``cvmfs_server import`` requires the full CernVM-FS 2.0 data
 storage which is located at /srv/cvmfs by default as well as the
-repository’s signing keys. Since the CernVM-FS 2.1 server backend
+repository’s signing keys. Since the CernVM-FS 2.1 server backend
 supports multiple repositories in contrast to its 2.0 counterpart, we
 recommend to move the repository’s data storage to /srv/cvmfs/<FQRN>
 upfront to avoid later inconsistencies.
 
 The following steps describe the transformation of a repository from
-CernVM-FS 2.0 into 2.1. As an example we are using a repository called
+CernVM-FS 2.0 into 2.1. As an example we are using a repository called
 **legacy.cern.ch**.
 
 #. Make sure that you have backups of both the repository’s backend
    storage and its signing keys
 
-#. Install and test the CernVM-FS 2.1 server tools on the machine that
+#. Install and test the CernVM-FS 2.1 server tools on the machine that
    is going to be used as new Stratum 0 maintenance machine
 
 #. | Place the repository’s backend storage data in
@@ -552,14 +552,14 @@ or more of the following shell script functions:
 
 The defined functions get called at the specified positions in the
 repository update process and are provided with the fully qualified
-repository name as their only parameter (\ ``$1``). Undefined functions
+repository name as their only parameter (\ ``$1``). Undefined functions
 automatically default to a NO-OP. An example script is located at
-``cvmfs/cvmfs_server_hooks.sh.demo`` in the CernVM-FS sources.
+``cvmfs/cvmfs_server_hooks.sh.demo`` in the CernVM-FS sources.
 
 Maintaining a CernVM-FS Repository
 ----------------------------------
 
-CernVM-FS is a versioning, snapshot-based file system. Similar to
+CernVM-FS is a versioning, snapshot-based file system. Similar to
 versioning systems, changes to /cvmfs/…are temporary until they are
 committed (``cvmfs_server publish``) or discarded
 (``cvmfs_server abort``). That allows you to test and verify changes,
@@ -580,7 +580,7 @@ by rolling back to the ``trunk-previous`` tag.
 Integrity Check
 ~~~~~~~~~~~~~~~
 
-CernVM-FS provides an integrity checker for repositories. It is invoked
+CernVM-FS provides an integrity checker for repositories. It is invoked
 by
 
 ::
@@ -610,7 +610,7 @@ Named Snapshots
 ~~~~~~~~~~~~~~~
 
 Named snapshots or *tags* are an easy way to organise checkpoints in the
-file system history. CernVM-FS clients can explicitly mount a repository
+file system history. CernVM-FS clients can explicitly mount a repository
 at a specific named snapshot to expose the file system content published
 with this tag. It also allows for rollbacks to previously created and
 tagged file system revisions. Tag names need to be unique for each
@@ -636,7 +636,7 @@ Creating a Named Snapshot
 
 Tags can be added while publishing a new file system revision. To do so,
 the -a and -m options for ``cvmfs_server publish`` are used. The
-following command publishes a CernVM-FS revision with a new revision
+following command publishes a CernVM-FS revision with a new revision
 that is tagged as “release-1.0”:
 
 ::
@@ -670,7 +670,7 @@ is irreversible.
 Managing Nested Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-CernVM-FS stores meta-data (path names, file sizes, …) in file catalogs.
+CernVM-FS stores meta-data (path names, file sizes, …) in file catalogs.
 When a client accesses a repository, it has to download the file catalog
 first and then it downloads the files as they are opened. A single file
 catalog for an entire repository can quickly become large and
@@ -678,7 +678,7 @@ impractical. Also, clients typically do not need all of the repository’s
 meta-data at the same time. For instance, clients using software release
 1.0 do not need to know about the contents of software release 2.0.
 
-With nested catalogs, CernVM-FS has a mechanism to partition the
+With nested catalogs, CernVM-FS has a mechanism to partition the
 directory tree of a repository into many catalogs. Repository
 maintainers are responsible for sensible cutting of the directory trees
 into nested catalogs. They can do so by creating and removing magic
@@ -852,13 +852,13 @@ catalogs in bytes.
 Syncing files into a repository with cvmfs\_rsync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A common method of publishing into CernVM-FS is to first install all the
+A common method of publishing into CernVM-FS is to first install all the
 files into a convenient shared filesystem, mount the shared filesystem
 on the publishing machine, and then sync the files into the repository
 during a transaction. The most common tool to do the syncing is
 ``rsync``, but ``rsync`` by itself doesn’t have a convenient mechanism
 for avoiding generated ``.cvmfscatalog`` and ``.cvmfsautocatalog`` files
-in the CernVM-FS repository. Actually the ``--exclude`` option is good
+in the CernVM-FS repository. Actually the ``--exclude`` option is good
 for avoiding the extra files, but the problem is that if a source
 directory tree is removed, then ``rsync`` will not remove the
 corresponding copy of the directory tree in the repository if it
@@ -882,13 +882,13 @@ This is an example use case:
 Migrate File Catalogs
 ~~~~~~~~~~~~~~~~~~~~~
 
-In rare cases the further development of CernVM-FS makes it necessary to
+In rare cases the further development of CernVM-FS makes it necessary to
 change the internal structure of file catalogs. Updating the
-CernVM-FS installation on a Stratum 0 machine might require a migration
+CernVM-FS installation on a Stratum 0 machine might require a migration
 of the file catalogs.
 
 It is recommended that ``cvmfs_server list`` is issued after any
-CernVM-FS update to review if any of the maintained repositories need a
+CernVM-FS update to review if any of the maintained repositories need a
 migration. Outdated repositories will be marked as “INCOMPATIBLE” and
 ``cvmfs_server`` refuses all actions on these repositories until the
 file catalogs have been updated.
@@ -941,12 +941,12 @@ the CernVM-FS repository will *not* be affected by this update.
 Repository Garbage Collection
 -----------------------------
 
-Since CernVM-FS is a versioning file system it is following an
+Since CernVM-FS is a versioning file system it is following an
 insert-only policy regarding its backend storage. When files are deleted
-from a CernVM-FS repository, they are not automatically deleted from the
+from a CernVM-FS repository, they are not automatically deleted from the
 underlying storage. Therefore legacy revisions stay intact and usable
 forever (cf. :ref:`sct_namedsnapshots`) at the expense of an
-ever-growing storage volume both on the Stratum 0 and the Stratum 1s.
+ever-growing storage volume both on the Stratum 0 and the Stratum 1s.
 
 For this reason, applications that frequently install files into a
 repository and delete older ones – for example the output from nightly
@@ -955,23 +955,23 @@ storage. Furthermore these applications might actually never make use of
 the aforementioned long-term revision preservation rendering most of the
 stored objects “garbage”.
 
-CernVM-FS supports garbage-collected repositories that automatically
+CernVM-FS supports garbage-collected repositories that automatically
 remove unreferenced data objects and free storage space. This feature
-needs to be enabled on the Stratum 0 and automatically scans the
+needs to be enabled on the Stratum 0 and automatically scans the
 repository’s catalog structure for unreferenced objects both on the
-Stratum 0 and the Stratum 1 installations on every publish respectively
+Stratum 0 and the Stratum 1 installations on every publish respectively
 snapshot operation.
 
 Garbage Sweeping Policy
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The garbage collector of CernVM-FS is using a mark-and-sweep algorithm
+The garbage collector of CernVM-FS is using a mark-and-sweep algorithm
 to detect unused files in the internal catalog graph. Revisions that are
 referenced by named snapshots (cf. :ref:`sct_namedsnapshots`) or that
 are recent enough are preserved while all other revisions are condemned
 to be removed. By default this time-based threshold is *three days* but
 can be changed using the configuration variable
-``CVMFS_AUTO_GC_TIMESPAN`` both on Stratum 0 and Stratum 1. The value of
+``CVMFS_AUTO_GC_TIMESPAN`` both on Stratum 0 and Stratum 1. The value of
 this variable is expected to be parseable by the ``date`` command, for
 example ``3 days ago`` or ``1 week ago``.
 
@@ -1010,17 +1010,17 @@ the stratum 1 installation. This will only work if the upstream stratum
 Limitations on Repository Content
 ---------------------------------
 
-Because CernVM-FS provides what appears to be a POSIX filesystem to
+Because CernVM-FS provides what appears to be a POSIX filesystem to
 clients, it is easy to think that it is a general purpose filesystem and
 that it will work well with all kinds of files. That is not the case,
-however, because CernVM-FS is optimized for particular types of files
+however, because CernVM-FS is optimized for particular types of files
 and usage. This section contains guidelines for limitations on the
 content of repositories for best operation.
 
 Data files
 ~~~~~~~~~~
 
-First and foremost, CernVM-FS is designed to distribute executable code
+First and foremost, CernVM-FS is designed to distribute executable code
 that is shared between a large number of jobs that run together at grid
 sites, clouds, or clusters. Worker node cache sizes and web proxy
 bandwidth are generally engineered to accommodate that application. The
@@ -1029,7 +1029,7 @@ amount of RAM per job slot. The same files are also expected to be read
 from the worker node cache multiple times for the same type of job, and
 read from a caching web proxy by multiple worker nodes.
 
-If there are data files distributed by CernVM-FS that follow similar
+If there are data files distributed by CernVM-FS that follow similar
 access patterns and size limits as executable code, it will probably
 work fine. In addition, if there are files that are larger but read
 slowly throughout long jobs, as opposed to all at once at the beginning,
@@ -1069,7 +1069,7 @@ first unpack it into its separate pieces first. This is because it
 allows better sharing of content between multiple releases of the file;
 some pieces inside the archive file might change and other pieces might
 not in the next release, and pieces that don’t change will be stored as
-the same file in the repository. CernVM-FS will compress the content of
+the same file in the repository. CernVM-FS will compress the content of
 the individual pieces, so even if there’s no sharing between releases it
 shouldn’t take much more space.
 
@@ -1090,12 +1090,12 @@ unless the client has set
 (and most do not), unprivileged users will not be able to read files
 unless they are readable by “other” and all their parent directories
 have at least “execute” permissions. It makes little sense to publish
-files in CernVM-FS if they won’t be able to be read by anyone.
+files in CernVM-FS if they won’t be able to be read by anyone.
 
 Hardlinks
 ~~~~~~~~~
 
-By default CernVM-FS does not allow hardlinks of a file to be in
+By default CernVM-FS does not allow hardlinks of a file to be in
 different directories. If there might be any such hardlinks in a
 repository, set the option
 

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -949,8 +949,8 @@ forever (cf. :ref:`sct_namedsnapshots`) at the expense of an
 ever-growing storage volume both on the Stratum 0 and the Stratum 1s.
 
 For this reason, applications that frequently install files into a
-repository and delete older ones – for example the output from nightly
-software builds – might quickly fill up the repository’s backend
+repository and delete older ones - for example the output from nightly
+software builds - might quickly fill up the repository’s backend
 storage. Furthermore these applications might actually never make use of
 the aforementioned long-term revision preservation rendering most of the
 stored objects “garbage”.

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -323,8 +323,8 @@ settings are given as parameters to ``cvmfs_server mkfs`` or
       cvmfs_server mkfs -s /etc/cvmfs/.../mys3.conf \
         -w http://s3.amazonaws.com/mybucket-1-1 my.repo.name
 
-The file “mys3.conf” contains the S3 settings (see :ref: `table below
-<tab_s3confparameters>`). The “-w” option is used define the S3 server URL,
+The file "mys3.conf" contains the S3 settings (see :ref: `table below
+<tab_s3confparameters>`). The "-w" option is used define the S3 server URL,
 e.g. http://localhost:3128, which is used for accessing the repository's
 backend storage on S3. Note that this URL can be different than the S3 server
 address that is used for uploads, e.g. if a proxy server is deployed in front
@@ -637,7 +637,7 @@ Creating a Named Snapshot
 Tags can be added while publishing a new file system revision. To do so,
 the -a and -m options for ``cvmfs_server publish`` are used. The
 following command publishes a CernVM-FS revision with a new revision
-that is tagged as “release-1.0”:
+that is tagged as "release-1.0":
 
 ::
 
@@ -889,7 +889,7 @@ of the file catalogs.
 
 It is recommended that ``cvmfs_server list`` is issued after any
 CernVM-FS update to review if any of the maintained repositories need a
-migration. Outdated repositories will be marked as “INCOMPATIBLE” and
+migration. Outdated repositories will be marked as "INCOMPATIBLE" and
 ``cvmfs_server`` refuses all actions on these repositories until the
 file catalogs have been updated.
 
@@ -953,7 +953,7 @@ repository and delete older ones - for example the output from nightly
 software builds - might quickly fill up the repository's backend
 storage. Furthermore these applications might actually never make use of
 the aforementioned long-term revision preservation rendering most of the
-stored objects “garbage”.
+stored objects "garbage".
 
 CernVM-FS supports garbage-collected repositories that automatically
 remove unreferenced data objects and free storage space. This feature
@@ -1077,9 +1077,9 @@ File permissions
 ~~~~~~~~~~~~~~~~
 
 Care should be taken to make all the files in a repository readable by
-“other”. This is because permissions on files in the original repository
+"other". This is because permissions on files in the original repository
 are generally the same as those seen by end clients, except the files
-are owned by the “cvmfs” user and group. The write permissions are
+are owned by the "cvmfs" user and group. The write permissions are
 ignored by the client since it is a read-only filesystem. However,
 unless the client has set
 
@@ -1088,8 +1088,8 @@ unless the client has set
       CVMFS_CHECK_PERMISSIONS=no
 
 (and most do not), unprivileged users will not be able to read files
-unless they are readable by “other” and all their parent directories
-have at least “execute” permissions. It makes little sense to publish
+unless they are readable by "other" and all their parent directories
+have at least "execute" permissions. It makes little sense to publish
 files in CernVM-FS if they won't be able to be read by anyone.
 
 Hardlinks
@@ -1108,4 +1108,4 @@ hardlinked to the client, but it will still be stored as only one file
 in the repository just like any other files that have identical content.
 Note that if, in a subsequent publish operation, only one of these
 cross-directory hardlinks gets changed, the other hardlinks remain
-unchanged (the hardlink got “broken”).
+unchanged (the hardlink got "broken").

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -397,7 +397,7 @@ create a new revision of a repository:
    CernVM-FS volume
 
 #. Make the necessary changes to the repository, add new directories,
-   patch certain binaries, …
+   patch certain binaries, ...
 
 #. Test the software installation
 
@@ -560,7 +560,7 @@ Maintaining a CernVM-FS Repository
 ----------------------------------
 
 CernVM-FS is a versioning, snapshot-based file system. Similar to
-versioning systems, changes to /cvmfs/…are temporary until they are
+versioning systems, changes to /cvmfs/...are temporary until they are
 committed (``cvmfs_server publish``) or discarded
 (``cvmfs_server abort``). That allows you to test and verify changes,
 for instance to test a newly installed release before publishing it to
@@ -670,7 +670,7 @@ is irreversible.
 Managing Nested Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-CernVM-FS stores meta-data (path names, file sizes, …) in file catalogs.
+CernVM-FS stores meta-data (path names, file sizes, ...) in file catalogs.
 When a client accesses a repository, it has to download the file catalog
 first and then it downloads the files as they are opened. A single file
 catalog for an entire repository can quickly become large and

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -114,7 +114,7 @@ machines.
 
 #. | Install the cvmfs-release package:
      ``yum install cvmfs-release*.rpm``
-   | This adds the CernVM yum repositories to your machine’s
+   | This adds the CernVM yum repositories to your machine's
      configuration.
 
 #. | Install the aufs enabled kernel from ``cernvm-kernel``:
@@ -325,7 +325,7 @@ settings are given as parameters to ``cvmfs_server mkfs`` or
 
 The file “mys3.conf” contains the S3 settings (see :ref: `table below
 <tab_s3confparameters>`). The “-w” option is used define the S3 server URL,
-e.g. http://localhost:3128, which is used for accessing the repository’s
+e.g. http://localhost:3128, which is used for accessing the repository's
 backend storage on S3. Note that this URL can be different than the S3 server
 address that is used for uploads, e.g. if a proxy server is deployed in front
 of the server. Note that the buckets need to exist before the repository is
@@ -456,26 +456,26 @@ installation before installing CernVM-FS 2.1 server tools.
 
 The command ``cvmfs_server import`` requires the full CernVM-FS 2.0 data
 storage which is located at /srv/cvmfs by default as well as the
-repository’s signing keys. Since the CernVM-FS 2.1 server backend
+repository's signing keys. Since the CernVM-FS 2.1 server backend
 supports multiple repositories in contrast to its 2.0 counterpart, we
-recommend to move the repository’s data storage to /srv/cvmfs/<FQRN>
+recommend to move the repository's data storage to /srv/cvmfs/<FQRN>
 upfront to avoid later inconsistencies.
 
 The following steps describe the transformation of a repository from
 CernVM-FS 2.0 into 2.1. As an example we are using a repository called
 **legacy.cern.ch**.
 
-#. Make sure that you have backups of both the repository’s backend
+#. Make sure that you have backups of both the repository's backend
    storage and its signing keys
 
 #. Install and test the CernVM-FS 2.1 server tools on the machine that
    is going to be used as new Stratum 0 maintenance machine
 
-#. | Place the repository’s backend storage data in
+#. | Place the repository's backend storage data in
      /srv/cvmfs/*legacy.cern.ch*
    | (default storage location)
 
-#. Transfer the repository’s signing keychain to the machine (f.e. to
+#. Transfer the repository's signing keychain to the machine (f.e. to
    /legacy\_keys/)
 
 #. Run ``cvmfs_server import`` like this:
@@ -615,7 +615,7 @@ at a specific named snapshot to expose the file system content published
 with this tag. It also allows for rollbacks to previously created and
 tagged file system revisions. Tag names need to be unique for each
 repository and are not allowed to contain spaces or spacial characters.
-Besides the actual tag’s name they can also contain a free descriptive
+Besides the actual tag's name they can also contain a free descriptive
 text and store a creation timestamp.
 
 Named snapshots are best to use for larger modifications to the
@@ -674,7 +674,7 @@ CernVM-FS stores meta-data (path names, file sizes, …) in file catalogs.
 When a client accesses a repository, it has to download the file catalog
 first and then it downloads the files as they are opened. A single file
 catalog for an entire repository can quickly become large and
-impractical. Also, clients typically do not need all of the repository’s
+impractical. Also, clients typically do not need all of the repository's
 meta-data at the same time. For instance, clients using software release
 1.0 do not need to know about the contents of software release 2.0.
 
@@ -738,7 +738,7 @@ the repository from old catalogs that have changed. In addition, each
 run only tends to access one version of any package so having a separate
 catalog per version avoids loading catalog information that will not be
 used. A nested catalog at the top level of each platform may make sense
-if there is a significant number of platform-specific files that aren’t
+if there is a significant number of platform-specific files that aren't
 included in other catalogs.
 
 It could also make sense to have a nested catalog under
@@ -751,7 +751,7 @@ than 1000 files and directories but not contain more than
 :math:`\approx`\ 200000 files. See :ref:`sct_inspectnested` how to find
 catalogs that do not satisfy this recommendation.
 
-Restructuring the repository’s directory tree is an expensive operation
+Restructuring the repository's directory tree is an expensive operation
 in CernVM-FS. Moreover, it can easily break client applications when
 they switch to a restructured file system snapshot. Therefore, the
 software directory tree layout should be relatively stable before
@@ -856,7 +856,7 @@ A common method of publishing into CernVM-FS is to first install all the
 files into a convenient shared filesystem, mount the shared filesystem
 on the publishing machine, and then sync the files into the repository
 during a transaction. The most common tool to do the syncing is
-``rsync``, but ``rsync`` by itself doesn’t have a convenient mechanism
+``rsync``, but ``rsync`` by itself doesn't have a convenient mechanism
 for avoiding generated ``.cvmfscatalog`` and ``.cvmfsautocatalog`` files
 in the CernVM-FS repository. Actually the ``--exclude`` option is good
 for avoiding the extra files, but the problem is that if a source
@@ -950,7 +950,7 @@ ever-growing storage volume both on the Stratum 0 and the Stratum 1s.
 
 For this reason, applications that frequently install files into a
 repository and delete older ones - for example the output from nightly
-software builds - might quickly fill up the repository’s backend
+software builds - might quickly fill up the repository's backend
 storage. Furthermore these applications might actually never make use of
 the aforementioned long-term revision preservation rendering most of the
 stored objects “garbage”.
@@ -958,7 +958,7 @@ stored objects “garbage”.
 CernVM-FS supports garbage-collected repositories that automatically
 remove unreferenced data objects and free storage space. This feature
 needs to be enabled on the Stratum 0 and automatically scans the
-repository’s catalog structure for unreferenced objects both on the
+repository's catalog structure for unreferenced objects both on the
 Stratum 0 and the Stratum 1 installations on every publish respectively
 snapshot operation.
 
@@ -1068,10 +1068,10 @@ file is desired to be distributed by CernVM-FS, it is usually better to
 first unpack it into its separate pieces first. This is because it
 allows better sharing of content between multiple releases of the file;
 some pieces inside the archive file might change and other pieces might
-not in the next release, and pieces that don’t change will be stored as
+not in the next release, and pieces that don't change will be stored as
 the same file in the repository. CernVM-FS will compress the content of
-the individual pieces, so even if there’s no sharing between releases it
-shouldn’t take much more space.
+the individual pieces, so even if there's no sharing between releases it
+shouldn't take much more space.
 
 File permissions
 ~~~~~~~~~~~~~~~~
@@ -1090,7 +1090,7 @@ unless the client has set
 (and most do not), unprivileged users will not be able to read files
 unless they are readable by “other” and all their parent directories
 have at least “execute” permissions. It makes little sense to publish
-files in CernVM-FS if they won’t be able to be read by anyone.
+files in CernVM-FS if they won't be able to be read by anyone.
 
 Hardlinks
 ~~~~~~~~~
@@ -1103,7 +1103,7 @@ repository, set the option
 
         CVMFS_IGNORE_XDIR_HARDLINKS=true
 
-in the repository’s ``server.conf``. The file will not appear to be
+in the repository's ``server.conf``. The file will not appear to be
 hardlinked to the client, but it will still be stored as only one file
 in the repository just like any other files that have identical content.
 Note that if, in a subsequent publish operation, only one of these

--- a/cpt-squid.rst
+++ b/cpt-squid.rst
@@ -3,30 +3,30 @@
 Setting up a Local Squid Proxy
 ==============================
 
-For clusters of nodes with CernVM-FS clients, we strongly recommend to
+For clusters of nodes with CernVM-FS clients, we strongly recommend to
 setup two or more `Squid forward proxy <http://www.squid-
 cache.org>`_ servers as well. The forward proxies will reduce the
 latency for the local worker nodes, which is critical for cold cache
 performance. They also reduce the load on the Stratum 1 servers.
 
-From what we have seen, a Squid server on commodity hardware scales well
+From what we have seen, a Squid server on commodity hardware scales well
 for at least a couple of hundred worker nodes. The more RAM and hard
 disk you can devote for caching the better. We have good experience with
 of memory cache and of hard disk cache. We suggest to setup two
-identical Squid servers for reliability and load-balancing. Assuming the
+identical Squid servers for reliability and load-balancing. Assuming the
 two servers are A and B, set
 
 ::
 
       CVMFS_HTTP_PROXY="http://A:3128|http://B:3128"
 
-Squid is very powerful and has lots of configuration and tuning
-options. For CernVM-FS we require only the very basic static content
-caching. If you already have a `Frontier Squid <http://frontier.cern.ch>`_ 
+Squid is very powerful and has lots of configuration and tuning
+options. For CernVM-FS we require only the very basic static content
+caching. If you already have a `Frontier Squid <http://frontier.cern.ch>`_ 
 [Blumenfeld08]_ [Dykstra10]_ installed you can use it as well for CernVM-FS.
 
 Otherwise, cache sizes and access control needs to be configured in
-order to use the Squid server with CernVM-FS. In order to do so, browse
+order to use the Squid server with CernVM-FS. In order to do so, browse
 through your /etc/squid/squid.conf and make sure the following lines
 appear accordingly:
 
@@ -40,10 +40,10 @@ appear accordingly:
       # 50 GB disk cache
       cache_dir ufs /var/spool/squid 50000 16 256
 
-Furthermore, Squid needs to allow access to all Stratum 1 servers. This
-is controlled through Squid ACLs. For the Stratum 1 servers for the
+Furthermore, Squid needs to allow access to all Stratum 1 servers. This
+is controlled through Squid ACLs. For the Stratum 1 servers for the
 cern.ch, egi.eu, and opensciencegrid.org domains, add the following
-lines to you Squid configuration:
+lines to you Squid configuration:
 
 ::
 
@@ -61,7 +61,7 @@ lines to you Squid configuration:
       acl cvmfs dst cvmfs-s1fnal.opensciencegrid.org
       http_access allow cvmfs
 
-The Squid configuration can be verified by ``squid -k parse``. Before
+The Squid configuration can be verified by ``squid -k parse``. Before
 the first service start, the cache space on the hard disk needs to be
 prepared by ``squid -z``. In order to make the increased number of file
 descriptors effective for Squid, execute ``ulimit -n 8192`` prior to


### PR DESCRIPTION
This replaces several unicode characters by its ASCII friends. Note that rST is actually unicode aware and is meant to use unicode characters instead of clumsy escape sequences. What I replaced are characters that are not easily distinguishable (writable) in a plain-text editor - see below.
For other characters (for example René - the accent aigu) stays unicode.

In detail:

* 0x00A0 (non breaking space) replaced by standard space
* 0x2013 (En dash – ) by standard -
* 0x2019 (Right single quote ’ ) by standard '
* 0x2026 (horizontal ellipsis … ) by three dots ...
* 0x201C/0x201D (left/right double quotes “ ” ) by "