### PR TITLE
fix for the cmake option used to install cvmfs_preloader

### DIFF
--- a/cpt-hpc.rst
+++ b/cpt-hpc.rst
@@ -112,7 +112,7 @@ Compiling ``cvmfs_preload`` from Sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to compile ``cvmfs_preload`` from sources, use the
-``-DBUILD_PRELOADER=on`` cmake option.
+``-DBUILD_PRELOADER=yes`` cmake option.
 
 
 Loopback File Systems for Nodes' Caches

--- a/cpt-hpc.rst
+++ b/cpt-hpc.rst
@@ -112,7 +112,7 @@ Compiling ``cvmfs_preload`` from Sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to compile ``cvmfs_preload`` from sources, use the
-``-DCVMFS_PRELOADER=on`` cmake option.
+``-DBUILD_PRELOADER=on`` cmake option.
 
 
 Loopback File Systems for Nodes' Caches


### PR DESCRIPTION
changes "-DCVMFS_PRELOADER=on" to "-DBUILD_PRELOADER=on".