### PR TITLE
Clarify the explanation of the kernel version needed.

### DIFF
--- a/apx-serverinfra.rst
+++ b/apx-serverinfra.rst
@@ -18,8 +18,12 @@ Prerequisites
 A CernVM-FS server installation depends on the following environment
 setup and tools to be in place:
 
--  kernel 4.2.x or RHEL7.3 or later (for OverlayFS) *or* aufs support built into
-   the kernel (see Section :ref:`sct_customkernelinstall`)
+-  Appropriate kernel version.  You must have ONE of the following:
+
+   -   kernel 4.2.x or later.
+   -   RHEL7.3 kernel (for OverlayFS)
+   -   Custom kernel compilation with `aufs` support the kernel (see
+       Section :ref:`sct_customkernelinstall`)
 
 -  Backend storage location available through HTTP
 


### PR DESCRIPTION
Ran across someone who read this bullet point and thought all clients
needed a custom kernel to use CVMFS.