### PR TITLE
remove old workaround for autofs bug

### DIFF
--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -62,10 +62,9 @@ To install, proceed according to the following steps:
     For the base setup, run ``cvmfs_config setup``. Alternatively, you
     can do the base setup by hand: ensure that ``user_allow_other`` is
     set in /etc/fuse.conf, ensure that ``/cvmfs /etc/auto.cvmfs`` is set
-    in /etc/auto.master and that the autofs service is running. If the autofs
-    service is systemd managed, ensure that the unit's "kill mode" is set to
-    ``process``. If you migrate from a previous version of CernVM-FS, check the
-    release notes if there is anything special to do for migration.
+    in /etc/auto.master and that the autofs service is running. If you 
+    migrate from a previous version of CernVM-FS, check the release notes 
+    if there is anything special to do for migration.
 
 **Step 3**
     Create /etc/cvmfs/default.local and open the file for editing.


### PR DESCRIPTION
This issue was already fixed in CVMFS v2.3.5 so a manual step is not needed. Trying to minimize the number of redundant configuration steps needed.