### PR TITLE
give alternate way to do gc

### DIFF
--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -1491,7 +1491,8 @@ set ::
 
 in order to activate garbage collection and to turn off CernVM-FS' versioning
 (provided that the content on such repositories is ephemeral).  Additionally,
-a regular cron job running ``cvmfs_server gc -af`` should be installed.
+a regular cron job running ``cvmfs_server gc -af`` should be installed, or the
+nightly build script should be updated to invoke ``cvmfs_server gc <repo name>``.
 
 
 Repositories for (Conditions) Data


### PR DESCRIPTION
I think a gc included with a build script may be more practical for publishing than a system-wide cron, because otherwise it will be hard to get the timing right to make sure they never happen at the same time (especially on a multi-tenant release manager machine).