### PR TITLE
Only the EL7 (not EL6) cvmfs-server RPM does this

### DIFF
--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -81,7 +81,7 @@ We suggest the following key parameters:
     **Note**: Port 8000 might be assigned to ``soundd``.  On SElinux systems,
     this assignment must be changed to the HTTP service by
     ``semanage port -m -t http_port_t -p tcp 8000``.  The ``cvmfs-server``
-    RPM executes this command as a post-installation script.
+    RPM for EL7 executes this command as a post-installation script.
 
 **DNS cache**
     A Stratum 1 does a lot of DNS lookups, so we recommend installing a


### PR DESCRIPTION
```
$ rpm -qp --scripts cvmfs-server-2.4.4-1.el6.x86_64.rpm | grep semanage
$ rpm -qp --scripts cvmfs-server-2.4.4-1.el7.centos.x86_64.rpm | grep semanage
/usr/sbin/semanage port -m -t http_port_t -p tcp 8000 2>/dev/null || :
```
  