### PR TITLE
Add hint for ordering mounts at boot with config repo

### DIFF
--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -102,6 +102,18 @@ Otherwise multiple CernVM-FS processes would collide in the same cache
 location. If a repository is needed under several paths, use a *bind
 mount* or use a :ref:`private file system mount point <sct_privatemount>`.
 
+If a configuration repository is required to mount other repositories,
+it will need to be mounted first.  Since /etc/fstab mounts are done in
+parallel at boot time, the order in /etc/fstab is not sufficient to make
+sure that happens.  On systemd-based systems this can be done by adding
+the option ``x-systemd.requires-mounts-for=<configrepo>`` on all the
+other mounts.  For example:
+
+::
+
+      config-egi.egi.eu /cvmfs/config-egi.egi.eu cvmfs defaults,_netdev,nodev 0 0
+      cms.cern.ch /cvmfs/cms.cern.ch cvmfs defaults,_netdev,nodev,x-systemd.requires-mounts-for=/cvmfs/config-egi.egi.eu 0 0
+
 .. _sct_privatemount:
 
 Private Mount Points


### PR DESCRIPTION
Somebody who is setting up a cvmfs NFS server gave me this hint.  Without doing this, `/cvmfs/config-osg.opensciencegrid.org` at boot time often had an error showing as
```
$ ls -la /cvmfs
ls: cannot access /cvmfs/config-osg.opensciencegrid.org: No such file or directory
total 0
drwxr-xr-x  12 root  root  287 Feb  4 09:44 .
dr-xr-xr-x. 18 root  root  275 Feb  4 09:54 ..
drwxr-xr-x   2 cvmfs cvmfs   6 Feb  4 09:43 atlas.cern.ch
drwxr-xr-x   2 cvmfs cvmfs   6 Feb  4 09:43 cms.cern.ch
d??????????  ? ?     ?       ?            ? config-osg.opensciencegrid.org
```