### PR TITLE
Clarify how to access the rawlink attribute

### DIFF
--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -725,7 +725,8 @@ information. There are several supported attributes:
     The loaded public RSA keys used for repository whitelist verification.
 
 **rawlink**
-    Shows unresolved variant symbolic links; only accessible as root.
+    Shows unresolved variant symbolic links; only accessible from the
+    root attribute namespace (use `attr -Rg rawlink`).
 
 **repo\_counters**
     Shows the aggregate counters of the repository contents (number of files


### PR DESCRIPTION
I found that the "rawlink" attribute required the attr -R option to read it.  It also requires running as root on EL6, but it does not on EL7.  Given the limited lifetime left to EL6 I don't think it's worth mentioning that requirement.