### PR TITLE
Update advice on running on HPC systems

### DIFF
--- a/cpt-hpc.rst
+++ b/cpt-hpc.rst
@@ -13,12 +13,11 @@ other nodes with respect to CernVM-FS
 These problems can be overcome as described in the following sections.
 
 
-Using Singularity pre-mounts
-----------------------------
-If the fuse package is not available but `Singularity` 3.4 or later is
-installed on the supercomputer, the CernVM-FS Fuse client can be used
-from inside of a container via the Fuse3 "pre-mount" feature.  See
-:ref:`Pre-mounting <sct_premount>`.
+Running CernVM-FS as an unprivileged user
+-----------------------------------------
+CernVM-FS can be run as an unprivileged user under several different
+scenarios.  See documentation about that in the relevant
+[Security section](apx-security.html#running-the-client-as-a-normal-user).
 
 
 Parrot-Mounted CernVM-FS in lieu of Fuse Module
@@ -45,16 +44,32 @@ this approach has the following advantages:
     and variant symlinks (symlinks resolved according to environment variables).
 
 
+Downloading complete snapshots of CernVM-FS repositories
+--------------------------------------------------------
+
+When there is no possible way to run the CernVM-FS client, an option
+that has been used on some HPC systems is to download entire snapshots
+of CernVM-FS repositories using the
+[cvmfs_shrinkwrap tool](cpt-shrinkwrap.html).  This has many
+disadvantages compared to running a CernVM-FS client so it is typically
+a last resort.
+
+
 Preloading the CernVM-FS Cache
 ------------------------------
 
-The
+When the CernVM-FS client can be installed on the worker node but for
+whatever reason on-demand downloading to a local cache is difficult, the
 `cvmfs_preload utility <http://cernvm.cern.ch/portal/filesystem/downloads>`_
 can be used to preload a CernVM-FS cache onto the shared cluster file system.
 Internally it uses the same code that is used to replicate between CernVM-FS
 stratum 0 and stratum 1.  The ``cvmfs_preload`` command is a self-extracting
 binary with no further dependencies and should work on a majority of x86_64
-Linux hosts.
+Linux hosts.  Note however that this method can significantly strain the
+cluster file system's meta-data server(s) and that many HPC systems have
+had better results with
+[loopback filesystems](#loopback-file-systems-for-nodes-caches) as node
+caches as discussed below.
 
 The ``cvmfs_preload`` command replicates from a stratum 0 (not from a
 stratum 1). Because this induces significant load on the source server,
@@ -139,9 +154,11 @@ an xfs file system. These files can be created with the ``dd`` and ``mkfs``
 utilities. Nodes can mount these files as loopback file systems from the
 shared file system.
 
-Because there is only a single file for every node, the parallelism of the
-cluster file system can be exploited and all the requests from CernVM-FS
-circumvent the cluster file system's meta-data server(s).
+Because there is only a single file for every node, the parallelism of
+the cluster file system can be exploited and all the requests from
+CernVM-FS circumvent the cluster file system's meta-data server(s).
+That can be a very large advantage because very often the meta-data
+server is the bottleneck under typical workloads.
 
 
 Tiered Cache and Cache Plugins


### PR DESCRIPTION
Added links to unprivileged cvmfs and to cvmfs_shrinkwrap while adding judgements on each of the various methods to provide advice.

This was prompted by an OSG user who, after reading that documentation page, thought that cvmfs_preload was his best option for getting a cvmfs repository on an HPC that could not install a cvmfs client.  