### PR TITLE
Fix cvmfs param

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1,0 +1,16 @@
+/* modified from https://github.com/readthedocs/sphinx_rtd_theme/issues/295#issuecomment-560895037 */
+
+.wy-nav-content {
+    max-width: 1200px !important;
+}
+
+/* and fix wrap bug per https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html */
+.wy-table-responsive table td {
+    /* !important prevents the common CSS stylesheets from overriding
+    this as on RTD they are loaded after this stylesheet */
+    white-space: normal !important;
+}
+
+.wy-table-responsive {
+    overflow: visible !important;
+}

--- a/apx-parameters.rst
+++ b/apx-parameters.rst
@@ -62,10 +62,10 @@ CVMFS_INSTRUMENT_FUSE           | When set to *true* gather performance statisti
                                 | The results are displayed with `cvmfs_talk internal affairs`.
 CVMFS_NFS_INTERLEAVED_INODES    In NFS mode, use only inodes of the form :math:`an+b`, specified as "b%a".
 CVMFS_IPFAMILY_PREFER           Which IP protocol to prefer when connecting to proxies.  Can be either 4 or 6.
-CVMFS_KCACHE_TIMEOUT            Timeout for path names and file attributes in the kernel file system buffers.
+CVMFS_KCACHE_TIMEOUT            Timeout in seconds for path names and file attributes in the kernel file system buffers.
 CVMFS_KEYS_DIR                  | Directory containing \*.pub files used as repository signing keys.
                                 | If set, this parameter has precedence over ``CVMFS_PUBLIC_KEY``.
-CVMFS_LOW_SPEED_LIMIT           Minimum transfer rate a server or proxy must provide.
+CVMFS_LOW_SPEED_LIMIT           Minimum transfer rate in bytes/second a server or proxy must provide.
 CVMFS_MAX_EXTERNAL_SERVERS      | Limit the number of (geo sorted) stratum 1 servers for external data
                                 | that are effectively used.
 CVMFS_MAX_IPADDR_PER_PROXY      | Limit the number of IP addresses a proxy names resolves into.
@@ -171,7 +171,6 @@ CVMFS_FILE_MBYTE_LIMIT              | Maximum number of megabytes for a publishe
 CVMFS_FORCE_REMOUNT_WARNING         | Enable/disable warning through ``wall`` and grace period before forcefully
                                     | remounting a CernVM-FS repository on the release managere machine.
 CVMFS_GARBAGE_COLLECTION            Enables repository garbage collection |br| (Stratum~0 only | if set to *true*)
-CVMFS_GENERATE_LEGACY_BULK_CHUNKS   | Deprecated, set to *true* to enable generation of whole-file objects for large files.
 CVMFS_GC_DELETION_LOG               | Log file path to track all garbage collected objects during sweeping
                                     | for bookkeeping or debugging
 CVMFS_GEO_DB_FILE                   Path to externally updated location of geolite2 city database, or 'None' for no database.
@@ -179,9 +178,7 @@ CVMFS_GEO_LICENSE_KEY               A license key for downloading the geolite2 c
 CVMFS_GID_MAP                       Path of a file for the mapping of file owner group ids.
 CVMFS_HASH_ALGORITHM                | Define which secure hash algorithm should be used by CernVM-FS for CAS objects
                                     | (supported are: *sha1*, *rmd160* and *shake128*)
-CVMFS_IGNORE_SPECIAL_FILES          Set to *true* to skip special files during publish without aborting.
-CVMFS_IGNORE_XDIR_HARDLINKS         | Deprecated, defaults to *true*
-                                    | hardlinks are found. Instead automatically break the hardlinks across directories.
+CVMFS_IGNORE_SPECIAL_FILES          Set to *true* to skip special files (pipes, sockets, block device and character device files) during publish without aborting.
 CVMFS_INCLUDE_XATTRS                Set to *true* to process extended attributes
 CVMFS_MAX_CHUNK_SIZE                Maximal size of a file chunk in bytes (see also *CVMFS_USE_FILE_CHUNKING*)
 CVMFS_MAXIMAL_CONCURRENT_WRITES     Maximal number of concurrently processed files during publishing.
@@ -234,6 +231,20 @@ X509_CERT_BUNDLE                    Bundle file with CA certificates for HTTPS c
 X509_CERT_DIR                       | Directory file with CA certificates for HTTPS connections,
                                     | defaults to /etc/grid-security/certificates (see :ref:`sct_data`)
 =================================== ====================================================================================
+
+Deprecated parameters
+^^^^^^^^^^^^^^^^^^^^^
+
+Will be removed in future versions.
+
+=================================== ====================================================================================
+**Parameter**                       **Meaning**
+=================================== ====================================================================================
+CVMFS_GENERATE_LEGACY_BULK_CHUNKS   | Deprecated, set to *true* to enable generation of whole-file objects for large files.
+CVMFS_IGNORE_XDIR_HARDLINKS         | Deprecated, defaults to *true*
+                                    | hardlinks are found. Instead automatically break the hardlinks across directories.
+=================================== ====================================================================================
+
 
 Format of CVMFS_UPSTREAM_STORAGE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/conf.py
+++ b/conf.py
@@ -128,7 +128,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -153,6 +153,12 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'css/custom.css',
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Related to https://github.com/cvmfs/cvmfs/issues/3038

- fix cvmfs parameters

layout style fixes:
- extend maximum page width from 800px to 1200px
- tables now have automatic wordwrap when page gets smaller

--> possible future todo: right now there are some "not so good looking" whitespaces due usage of "|". with the new wordwrap etc this might be not needed anymore for all the cases?