### PR TITLE
change contact link to GitHub issue tracker

### DIFF
--- a/apx-contact.rst
+++ b/apx-contact.rst
@@ -1,10 +1,8 @@
 Contact Information
 ===================
 
-For support requests and bug reports, please submit a JIRA ticket in our
-`issue tracker <https://sft.its.cern.ch/jira/projects/CVM>`_. If you do not have
-a CERN account, you can register yourself for an
-`external account <https://account.cern.ch/account/Externals/RegisterAccount.aspx>`_.
+For support requests and bug reports, please submit a GitHub issue in our
+`issue tracker <https://github.com/cvmfs/cvmfs/issues>`_.
 
 Together with bug reports, please attach a "bugreport tarball", which is created
 with ``sudo cvmfs_config bugreport``.


### PR DESCRIPTION
The Jira issue tracker just tells folks to go to the GitHub issue tracker, so might as well direct them there from the start.