### PR TITLE
Big cleanup

### DIFF
--- a/apx-contact.rst
+++ b/apx-contact.rst
@@ -4,7 +4,7 @@ Contact Information
 For support requests and bug reports, please submit a GitHub issue in our
 `issue tracker <https://github.com/cvmfs/cvmfs/issues>`_.
 
-Together with bug reports, please attach a "bugreport tarball", which is created
+Together with bug reports, please attach a "bug report tarball", which is created
 with ``sudo cvmfs_config bugreport``.
 
 Discourse Forum

--- a/apx-issues.rst
+++ b/apx-issues.rst
@@ -4,6 +4,6 @@ Known Issues
 Publisher nodes with AUFS and XFS
 ---------------------------------
 
-If the /tmp file system is on xfs, the publisher node cannot be used with AUFS.
+If the ``/tmp`` file system is on xfs, the publisher node cannot be used with AUFS.
 On such systems, adding the mount option ``xino=/dev/shm/aufs.xino`` can be
 a workaround. In general, new repositories should use OverlayFS if available.

--- a/apx-parameters.rst
+++ b/apx-parameters.rst
@@ -60,7 +60,7 @@ CVMFS_HTTP_PROXY                | Chain of HTTP proxy groups used by CernVM-FS. 
 CVMFS_IGNORE_SIGNATURE          When set to *yes*, don't verify CernVM-FS file catalog signatures.
 CVMFS_INITIAL_GENERATION        Initial inode generation.  Used for testing.
 CVMFS_INSTRUMENT_FUSE           | When set to *true* gather performance statistics about the FUSE callbacks.
-                                | The results are displayed with `cvmfs_talk internal affairs`.
+                                | The results are displayed with ``cvmfs_talk internal affairs``.
 CVMFS_NFS_INTERLEAVED_INODES    In NFS mode, use only inodes of the form :math:`an+b`, specified as "b%a".
 CVMFS_INFLUX_EXTRA_FIELDS       Static fields always attached to the (absolute) output of the InfluxDB Telemetry Aggregator
 CVMFS_INFLUX_EXTRA_TAGS         Static tags always attached to the (absolute + delta) output of the InfluxDB Telemetry Aggregator
@@ -79,7 +79,7 @@ CVMFS_MAX_IPADDR_PER_PROXY      | Limit the number of IP addresses a proxy names
 CVMFS_MAX_RETRIES               Maximum number of retries for a given proxy/host combination.
 CVMFS_MAX_SERVERS               Limit the number of (geo sorted) stratum 1 servers that are effectively used.
 CVMFS_MAX_TTL                   Maximum file catalog TTL in minutes.  Can overwrite the TTL stored in the catalog.
-CVMFS_MEMCACHE_SIZE             Size of the CernVM-FS meta-data memory cache in Megabyte.
+CVMFS_MEMCACHE_SIZE             Size of the CernVM-FS metadata memory cache in Megabyte.
 CVMFS_MOUNT_RW                  | Mount CernVM-FS as a read/write file system.  Write operations will fail
                                 | but this option can workaround faulty ``open()`` flags.
 CVMFS_NFILES                    Maximum number of open file descriptors that can be used by the CernVM-FS process.
@@ -222,7 +222,7 @@ CVMFS_UNION_DIR                     | Mount point of the union file system for c
                                     | Here, changes to the repository are performed
                                     | (see :ref:`sct_repocreation_update`).
 CVMFS_UNION_FS_TYPE                 | Defines the union file system to be used for the repository.
-                                    | (currently `aufs` and `overlayfs` are fully supported)
+                                    | (only ``overlayfs`` is fully supported, ``aufs`` has no active support anymore)
 CVMFS_UPLOAD_STATS_DB               | Publish repository statistics data file to the Stratum 0 /stats location
 CVMFS_UPLOAD_STATS_PLOTS            | Publish repository statistics plots and webpage to the Stratum 0 /stats location (requires ROOT)
 CVMFS_UPSTREAM_STORAGE              | Upstream spooler description defining the basic upstream storage type

--- a/apx-rpms.rst
+++ b/apx-rpms.rst
@@ -14,12 +14,12 @@ The CernVM-FS software is available in form of several packages:
     cern.ch, egi.eu, and opensciencegrid.org domains.
 
 **cvmfs-config-none**
-    Empty package to satisfy the cvmfs-config requirement of the cvmfs
+    Empty package to satisfy the ``cvmfs-config`` requirement of the cvmfs
     package without actually installing any configuration.
 
 **cvmfs**
     Contains the Fuse module and additional client tools. It has
-    dependencies to at least one of the cvmfs-config-\ :math:`\cdots`
+    dependencies to at least one of the ``cvmfs-config-...``
     packages.
 
 **cvmfs-fuse3**
@@ -50,12 +50,12 @@ The CernVM-FS software is available in form of several packages:
     on a publisher node.
 
 **cvmfs-notify**
-    Websockets frontend for used for repository update notifications. Supposed
+    WebSockets frontend for used for repository update notifications. Supposed
     to be co-located with a RabbitMQ service.
 
 **kernel-...-.aufs21**
-    Scientific Linux 6 kernel with aufs. Required for SL6 based
-    Stratum 0 servers.
+    Scientific Linux 6 kernel with ``aufs``. Required for SL6 based
+    Stratum 0 servers. (Note: no active support for ``aufs`` anymore)
 
 **cvmfs-shrinkwrap**
     Stand-alone utility to export file system trees into containers for HPC

--- a/apx-security.rst
+++ b/apx-security.rst
@@ -4,47 +4,47 @@ Security Considerations
 =======================
 
 CernVM-FS provides end-to-end data integrity and authenticity using a signed
-Merkle Tree.  CernVM-FS clients verify the signature and the content hashes of
-all downloaded data.  Once a particular revision of a file system is stored in
+Merkle Tree. CernVM-FS clients verify the signature and the content hashes of
+all downloaded data. Once a particular revision of a file system is stored in
 a client's local cache, the client will not apply an older revision anymore.
 
 The public key used to ultimately verify a repository's signature needs to be
 distributed to clients through a channel different from CernVM-FS content
-distribution.  In practice, these public keys are distributed as part of the
-source code or through ``cvmfs-config-...`` packages.  One or multiple public
+distribution. In practice, these public keys are distributed as part of the
+source code or through ``cvmfs-config-...`` packages. One or multiple public
 keys can be configured for a repository (the *fully qualified repository name*),
 all repositories within a specific domain (like ``*.cern.ch``) or all
-repositories (``*``).  If multiple keys are configured, it is sufficient if any
+repositories (``*``). If multiple keys are configured, it is sufficient if any
 of them validates a signature.
 
 Besides the client, data is also verified by the replication code (Stratum 1 or
 preloaded cache) and by the release manager machine in case the repository is
 stored in S3 and not on a local file system.
 
-CernVM-FS does **not** provide data confidentiality out of the box.  By default
+CernVM-FS does **not** provide data confidentiality out of the box. By default,
 data is transferred through HTTP and thus only public data should be stored on
-CernVM-FS.  However, CernVM-FS can be operated with HTTPS data transport.  In
+CernVM-FS. However, CernVM-FS can be operated with HTTPS data transport. In
 combination with client-authentication using an authz helper (see Section
 :ref:`sct_authz`), CernVM-FS can be configured for end-to-end data
 confidentiality.
 
 Once downloaded and stored in a cache, the CernVM-FS client fully trusts the
-cache.  Data in the cache can be checked for silent corruption but no integrity
+cache. Data in the cache can be checked for silent corruption but no integrity
 re-check takes place.
 
 Signature Details
 -----------------
 
-Creating and validating a repository signature is a two-step process.  The
+Creating and validating a repository signature is a two-step process. The
 *repository manifest* (the file ``.cvmfspublished``) is signed by a private RSA
 key whose public part is stored in the form of an X.509 certificate in the
-repository.  The fingerprint of all certificates that are allowed to sign a
+repository. The fingerprint of all certificates that are allowed to sign a
 repository is stored on a *repository whitelist* (the file ``.cvmfswhitelist``).
 The whitelist is signed with a different RSA key, the *repository master key*.
 Only the public part of this master key needs to be distributed to clients.
 
 The X.509 certificate currently only serves as an envelope for the public part
-of a repository key.  No further certificate validation takes place.
+of a repository key. No further certificate validation takes place.
 
 The repository manifest contains, among other information, the content hash of
 the root file catalog, the content hash of the signing certificate, the fully
@@ -53,11 +53,11 @@ content of the manifest is hashed and encrypted with a private repository key.
 The timestamp and repository name are used prevent replay attacks.
 
 The whitelist contains the fully qualified repository name, a creation
-timestamp, an expiry timestamp, and the certificate fingerprints.  Since the
+timestamp, an expiry timestamp, and the certificate fingerprints. Since the
 whitelist expires, it needs to be regularly resigned.
 
 The private part of the repository key needs to be accessible on the release
-manager machine.  The private part of the repository master key used to sign the
+manager machine. The private part of the repository master key used to sign the
 whitelist *can* be maintained on a file on the release manager machine.
 We recommend, however, to use a smart card to store this private key.
 See section :ref:`sct_master_keys` for more details.
@@ -67,27 +67,27 @@ Content Hashes
 --------------
 
 CernVM-FS supports multiple content hash algorithms: SHA-1 (default),
-RIPEMD-160, and SHAKE-128 with 160 output bits.  The content hash algorithm
-can be changed with every repository publish operation.  Files and file catalogs
-hashed with different content hash algorithms can co-exist.  On changing the
+RIPEMD-160, and SHAKE-128 with 160 output bits. The content hash algorithm
+can be changed with every repository publish operation. Files and file catalogs
+hashed with different content hash algorithms can co-exist. On changing the
 algorithm, new and changed files are hashed with the new algorithm, existing
-data remains unchanged.  That allows seamless migration from one algorithm to
+data remains unchanged. That allows seamless migration from one algorithm to
 another.
 
 
 Local UNIX Permissions
 ----------------------
 
-Most parts of CernVM-FS do not require root privileges.  On the server side,
+Most parts of CernVM-FS do not require root privileges. On the server side,
 only creating and deleting a repository (or replica) requires root privileges.
 Repository transactions and snapshots can be performed with an unprivileged user
-account.  In order to remount a new file system revision after publishing a
-transaction, the release manager machines uses a custom suid binary.
+account. In order to remount a new file system revision after publishing a
+transaction, the release manager machine uses a custom suid binary.
 
-On client side, the CernVM-FS fuse module is normally started as root.  It drops
+On client side, the CernVM-FS fuse module is normally started as root. It drops
 root privileges and changes the persona to the ``cvmfs`` user early in the file
-system initialization.  The client RPM package installs SElinux rules for RHEL6
-and RHEL7.  The cache directory should be labeled as ``cvmfs_cache_t``.
+system initialization. The client RPM package installs SElinux rules for RHEL6
+and RHEL7. The cache directory should be labeled as ``cvmfs_cache_t``.
 
 
 .. _sct_running_client_as_normal_user:
@@ -96,15 +96,15 @@ Running the client as a normal user
 -----------------------------------
 
 The client can also be started as a normal user. In this case, the user needs
-to have access to /dev/fuse.  On Linux kernels < 4.18, mounting /dev/fuse is
+to have access to /dev/fuse. On Linux kernels < 4.18, mounting /dev/fuse is
 either performed by fuse's ``fusermount`` utility or through a pre-mounted file
 descriptor. On newer Linux kernels, the client can mount as an unprivileged
 user in a user namespace with a detached mount namespace.
 
 The easiest way to run the client as a normal user is with the
-`cvmfsexec <https://github.com/cvmfs/cvmfsexec>`_ package.  It supports
+`cvmfsexec <https://github.com/cvmfs/cvmfsexec>`_ package. It supports
 four ways to run cvmfs as an unprivileged user, depending on the
-capabilities available on the host.  See the README there for details.
+capabilities available on the host. See the README there for details.
 
 
 SETUID bit and file capabilities
@@ -120,7 +120,7 @@ and file capabilities is restored.
 CernVM-FS Software Distribution
 -------------------------------
 
-CernVM-FS software is distributed through HTTPS in packages.  There are yum and
-apt repositories for Linux and ``pkg`` packages for OS X.  Software is available
-from HTTPS servers.  The Linux packages and repositories are signed with a GPG
+CernVM-FS software is distributed through HTTPS in packages. There are yum and
+apt repositories for Linux and ``pkg`` packages for OS X. Software is available
+from HTTPS servers. The Linux packages and repositories are signed with a GPG
 key.

--- a/apx-serverinfra.rst
+++ b/apx-serverinfra.rst
@@ -18,7 +18,7 @@ Prerequisites
 A CernVM-FS server installation depends on the following environment
 setup and tools to be in place:
 
--  Appropriate kernel version.  You must have ONE of the following:
+-  Appropriate kernel version. You must have ONE of the following:
 
    -   kernel 4.2.x or later.
    -   RHEL7.3 kernel (for OverlayFS)
@@ -34,7 +34,7 @@ Local Backend Storage Infrastructure
 ------------------------------------
 
 CernVM-FS stores the entire repository content (file content and
-meta-data catalogs) into a content addressable storage (CAS). This
+metadata catalogs) into a content addressable storage (CAS). This
 storage can either be a file system at ``/srv/cvmfs`` or an S3
 compatible object storage system (see ":ref:`sct_s3storagesetup`" for
 details). In the former case the contents of ``/srv/cvmfs`` are as
@@ -148,7 +148,7 @@ Repository Configuration Directory
 
 The authoritative configuration of a CernVM-FS repository is located in
 ``/etc/cvmfs/repositories.d`` and should only be writable by the
-administrator. Furthermore the repository's keychain is located in
+administrator. Furthermore, the repository's keychain is located in
 ``/etc/cvmfs/keys`` and follows the naming convention ``<fqrn>.crt`` for
 the certificate, ``<fqrn>.key`` for the repository's private key and
 ``<fqrn>.pub`` for the public key. All of those files can be symlinked
@@ -199,14 +199,14 @@ chosen backend storage type. For an S3 hosted backend storage, the
 CernVM-FS client can usually be directly pointed to the S3 bucket used
 for storage (see ":ref:`sct_s3storagesetup`" for details). In case of a
 local file system backend any web server can be used for this purpose.
-By default CernVM-FS assumes Apache and uses that automatically.
+By default, CernVM-FS assumes Apache and uses that automatically.
 
 Internally the CernVM-FS server uses a SUID binary (i.e.
 ``cvmfs_suid_helper``) to manipulate its mount points. This is necessary
 since transactional CernVM-FS commands must be accessible to the
 repository owner that is usually different from root. Both the mount
 directives for ``/var/spool/cvmfs/<fqrn>/rdonly`` and ``/cvmfs/<fqrn>``
-must be placed into ``/etc/fstab`` for this reason. By default
+must be placed into ``/etc/fstab`` for this reason. By default,
 CernVM-FS uses the following entries for these mount points:
 
 ::

--- a/conf.py
+++ b/conf.py
@@ -68,7 +68,7 @@ release = u'2.11.0-devel'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language ="en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -6,13 +6,13 @@ Structure of /etc/cvmfs
 
 The local configuration of CernVM-FS is controlled by several files in
 ``/etc/cvmfs`` listed in the table below. For every .conf file
-except for the files in /etc/cvmfs/default.d you can create a
-corresponding .local file having the same prefix in order to customize
-the configuration. The .local file will be sourced after the
-corresponding .conf file.
+except for the files in ``/etc/cvmfs/default.d`` you can create a
+corresponding ``.local`` file having the same prefix in order to customize
+the configuration. The ``.local`` file will be sourced after the
+corresponding ``.conf`` file.
 
 In a typical installation, a handful of parameters need to be set in
-/etc/cvmfs/default.local. Most likely, this is the list of repositories
+``/etc/cvmfs/default.local``. Most likely, this is the list of repositories
 (``CVMFS_REPOSITORIES``), HTTP proxies (see :ref:`network settings <sct_network>`),
 and perhaps the cache directory and the cache quota (see
 :ref:`cache settings <sct_cache>`). In a few cases, one might change a parameter
@@ -20,7 +20,7 @@ for a specific domain or a specific repository, or provide an exclusive cache fo
 a specific repository. For a list of all
 parameters, see Appendix ":ref:`apxsct_clientparameters`".
 
-The .conf and .local configuration files are key-value pairs in the form
+The ``.conf`` and ``.local`` configuration files are key-value pairs in the form
 ``PARAMETER=value``. They are sourced by /bin/sh. Hence, a limited set
 of shell commands can be used inside these files including comments,
 ``if`` clauses, parameter evaluation, and shell math (``$((...))``).
@@ -58,14 +58,14 @@ The Config Repository
 In addition to the local system configuration, a client can configure a
 dedicated config repository. A config repository is a standard
 mountable CernVM-FS repository that resembles the directory structure of
-/etc/cvmfs. It can be used to centrally maintain the public keys and
+``/etc/cvmfs``. It can be used to centrally maintain the public keys and
 configuration of repositories that should not be distributed with rather
 static packages, and also to centrally
 :ref:`blacklist <sct_blacklisting>` compromised repository keys.
 Configuration from the config repository is overwritten
 by the local configuration in case of conflicts; see the comments in
-/etc/cvmfs/default.conf for the precise ordering of processing
-the config files.  The config repository
+``/etc/cvmfs/default.conf`` for the precise ordering of processing
+the config files. The config repository
 is set by the ``CVMFS_CONFIG_REPOSITORY`` parameter. The default
 configuration rpm cvmfs-config-default sets this parameter to
 cvmfs-config.cern.ch.
@@ -74,17 +74,17 @@ The ``CVMFS_CONFIG_REPO_REQUIRED`` parameter can be used to force availability
 of the config repository in order for other repositories to get mounted.
 
 The config repository is a very convenient method for updating the
-configuration on a lot of CernVM-FS clients at once.  This also means
+configuration on a lot of CernVM-FS clients at once. This also means
 that it is very easy to break configurations on a lot of clients at
-once.  Also note that only one config repository may be used per client,
-and this is a technical limitation that is not expected to change.  For
+once. Also note that only one config repository may be used per client,
+and this is a technical limitation that is not expected to change. For
 these reasons, it makes the most sense to reserve the use of this
 feature for large groups of sites that share a common infrastructure
-with trusted people that maintain the configuration repository.  In
+with trusted people that maintain the configuration repository. In
 order to facilitate sharing of configurations between the
 infrastructures, a
 `github repository <https://github.com/cvmfs-contrib/config-repo>`_
-has been set up.  Infrastructure maintainers are invited to collaborate
+has been set up. Infrastructure maintainers are invited to collaborate
 there.
 
 Some large sites that prefer to maintain control over their own client
@@ -93,9 +93,9 @@ processes to compare it to a repository from a larger infrastructure.
 They then quickly update their own config repository with whatever
 changes have been made to the infrastructure's config repository.
 
-Exchanges of configurations between limited numbers of sites that are
-also depending separately on a configuration repository is encouraged to
-be done by making rpm and/or dpkg packages and distributing them through 
+Exchanges of configurations between limited numbers of sites that
+also use their own separate configuration repository are encouraged to
+be done by making rpm and/or dpkg packages and distributing them through
 `cvmfs-contrib package repositories <https://cvmfs-contrib.github.io>`_.
 Keeping configurations up to date through packages is less convenient
 than the configuration repository but better than manually maintaining
@@ -104,12 +104,12 @@ configuration files.
 Mounting
 --------
 
-Mounting of CernVM-FS repositories is typically handled by autofs. Just
-by accessing a repository directory under /cvmfs (/cvmfs/atlas.cern.ch),
-autofs will take care of mounting. autofs will also automatically
+Mounting of CernVM-FS repositories is typically handled by ``autofs``. Just
+by accessing a repository directory under ``/cvmfs`` (``/cvmfs/atlas.cern.ch``),
+``autofs`` will take care of mounting. ``autofs`` will also automatically
 unmount a repository if it is not used for a while.
 
-Instead of using autofs, CernVM-FS repositories can be mounted manually
+Instead of using ``autofs``, CernVM-FS repositories can be mounted manually
 with the system's ``mount`` command. In order to do so, use the
 ``cvmfs`` file system type, like
 
@@ -124,18 +124,18 @@ Likewise, CernVM-FS repositories can be mounted through entries in
 
       atlas.cern.ch /mnt/test cvmfs defaults,_netdev,nodev 0 0
 
-Every mount point corresponds to a CernVM-FS process. Using autofs or
+Every mount point corresponds to a CernVM-FS process. Using ``autofs`` or
 the system's mount command, every repository can only be mounted once.
-Otherwise multiple CernVM-FS processes would collide in the same cache
+Otherwise, multiple CernVM-FS processes would collide in the same cache
 location. If a repository is needed under several paths, use a *bind
 mount* or use a :ref:`private file system mount point <sct_privatemount>`.
 
 If a configuration repository is required to mount other repositories,
-it will need to be mounted first.  Since /etc/fstab mounts are done in
+it will need to be mounted first. Since ``/etc/fstab mounts`` are done in
 parallel at boot time, the order in /etc/fstab is not sufficient to make
-sure that happens.  On systemd-based systems this can be done by adding
+sure that happens. On systemd-based systems this can be done by adding
 the option ``x-systemd.requires-mounts-for=<configrepo>`` on all the
-other mounts.  For example:
+other mounts. For example:
 
 ::
 
@@ -151,7 +151,7 @@ In contrast to the system's ``mount`` command which requires root
 privileges, CernVM-FS can also be mounted like other Fuse file systems
 by normal users. In this case, CernVM-FS uses parameters from one or
 several user-provided config files instead of using the files under
-/etc/cvmfs. CernVM-FS private mount points do not appear as ``cvmfs2``
+``/etc/cvmfs``. CernVM-FS private mount points do not appear as ``cvmfs2``
 file systems but as ``fuse`` file systems. The ``cvmfs_config`` and
 ``cvmfs_talk`` commands ignore privately mounted CernVM-FS repositories.
 On an interactive machine, private mount points are for instance
@@ -164,7 +164,7 @@ In order to mount CernVM-FS privately, use the ``cvmfs2`` command like
 
       cvmfs2 -o config=myparams.conf atlas.cern.ch /home/user/myatlas
 
-A minimal sample myparams.conf file could look like this:
+A minimal sample ``myparams.conf`` file could look like this:
 
 ::
 
@@ -181,8 +181,8 @@ cache directory. Use ``fusermount -u`` in order to unmount a privately
 mounted CernVM-FS repository.
 
 The private mount points can also be used to use the CernVM-FS Fuse
-module in case it has not been installed under /usr and /etc. If the
-public keys are not installed under /etc/cvmfs/keys, the directory of
+module in case it has not been installed under ``/usr`` and ``/etc``. If the
+public keys are not installed under ``/etc/cvmfs/keys``, the directory of
 the keys needs to be specified in the config file by
 ``CVMFS_KEYS_DIR=<directory>``. If the libcvmfs\_fuse.so resp.
 libcvmfs\_fuse3.so library is not installed in one of the standard search paths,
@@ -190,7 +190,7 @@ the ``CVMFS_LIBRARY_PATH`` variable has to be set accordingly for the ``cvmfs2``
 command.
 
 The easiest way to make use of CernVM-FS private mount points is with
-the ``cvmfsexec`` package.  Read about that in the Security
+the ``cvmfsexec`` package. Read about that in the Security
 :ref:`sct_running_client_as_normal_user` section.
 
 .. _sct_premount:
@@ -201,7 +201,7 @@ Pre-mounting
 In usual deployments, the ``fusermount`` utility from the system fuse package
 takes care of mounting a repository before handing of control to the CernVM-FS
 client. The ``fusermount`` utility is a suid binary because on older kernels
-and outside user name spaces, mounting is a privileged operation.
+and outside user namespaces, mounting is a privileged operation.
 
 As of libfuse3, the task of mounting /dev/fuse can be performed by any utility.
 This functionality has been added, for instance, to
@@ -215,12 +215,12 @@ available in the
 
 In order to use the pre-mount functionality in Singularity, create a
 container that has the ``cvmfs`` package and configuration installed in
-it, and also the corresponding ``cvmfs-fuse3`` package.  Bind-mount scratch
+it, and also the corresponding ``cvmfs-fuse3`` package. Bind-mount scratch
 space at ``/var/run/cvmfs`` and cache space at ``/var/lib/cvmfs``.
 For each desired repository, add a ``--fusemount`` option with
 ``container:cvmfs2`` followed by the repository name and mountpoint,
-separated by whitespace.  First mount the configuration repository if
-required.  For example:
+separated by whitespace. First mount the configuration repository if
+required. For example:
 
 ::
 
@@ -232,7 +232,7 @@ required.  For example:
 
 
 The ``singcvmfs`` command in the ``cvmfsexec`` package makes use of
-fuse pre-mounting.  Read more about that package in the Security
+fuse pre-mounting. Read more about that package in the Security
 :ref:`sct_running_client_as_normal_user` section.
 
 .. _sct_remounting_namespaces_containers:
@@ -256,8 +256,8 @@ The repository can then be unmounted, but it cannot be remounted
 until the ``sleep`` process dies.
 
 When this happens, ``cvmfs_config fuser <repo>`` can be used to identify
-all the processes using ``<repo>``. 
-The system administrator can then contact the owners of the procesess to
+all the processes using ``<repo>``.
+The system administrator can then contact the owners of the processes to
 ask to change the application behavior to avoid this situation (for
 example by using Singularity ``-p``), and the processes can be killed to
 enable the repository to be remounted.
@@ -282,14 +282,14 @@ It provides a convenient interface to handle CernVM-FS volume definitions.
 Bind mount from the host
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Docker >= 1.10, the autofs managed area /cvmfs can be directly mounted into
+On Docker >= 1.10, the ``autofs`` managed area ``/cvmfs`` can be directly mounted into
 the container as a shared mount point like
 
 ::
 
     docker run -it -v /cvmfs:/cvmfs:shared centos /bin/bash
 
-In order to bind mount an individual repository from the host, turn off autofs
+In order to bind mount an individual repository from the host, turn off ``autofs``
 on the host and mount the repository manually, like:
 
 ::
@@ -320,18 +320,18 @@ started in privileged mode, like
         docker run --privileged -i -t centos /bin/bash
 
 In such a container, CernVM-FS can be installed and used the usual way
-provided that autofs is turned off.
+provided that ``autofs`` is turned off.
 
 Parrot Connector to CernVM-FS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case Fuse cannot be be installed, the `parrot toolkit
+In case Fuse cannot be installed, the `parrot toolkit
 <http://ccl.cse.nd.edu/software/parrot>`_ provides a means to "mount"
 CernVM-FS on Linux in pure user space.
-Parrot sandboxes an application in a similar way gdb sandboxes an
-application. But instead of debugging the application,
+Parrot sandboxes are an application similar to gdb sandboxes.
+But instead of debugging the application,
 parrot transparently rewrites file system calls and can effectively
-provide /cvmfs to an application. We recommend to use the `latest
+provide ``/cvmfs`` to an application. We recommend using the `latest
 precompiled parrot <http://ccl.cse.nd.edu/software/downloadfiles.php>`_, which
 has CernVM-FS support built-in.
 
@@ -345,7 +345,7 @@ parrot, use
     export HTTP_PROXY='<SITE HTTP PROXY>'  # or 'DIRECT;' if not on a cluster or grid site
     parrot_run <PARROT_OPTIONS> <CMD> <OPTIONS>
 
-Repositories that are not available by default from the builtin
+Repositories that are not available by default from the built-in
 ``<default-repositories>`` list can be explicitly added to
 ``PARROT_CVMFS_REPO``. The repository name, a stratum 1 URL, and the
 public key of the repository need to be provided. For instance, in order
@@ -364,7 +364,7 @@ given that the repository public keys are in the provided paths.
 
 By default, parrot uses a shared CernVM-FS cache for all parrot
 instances of the same user stored under a temporary directory that is
-derived from the user id. In order to place the CernVM-FS cache into a
+derived from the user ID. In order to place the CernVM-FS cache into a
 different directory, use
 
 ::
@@ -387,11 +387,11 @@ CernVM-FS Stratum 1 service, whereas the replication source server is
 the CernVM-FS Stratum 0 server. In every cluster of client machines,
 there should be two or more web proxy servers that CernVM-FS can use
 (see :ref:`cpt_squid`). These site-local web proxies reduce the
-network latency for the CernVM-FS clients and they reduce the load for
-the Stratum 1 service. CernVM-FS supports WPAD/PAC proxy auto
-configuration [Gauthier99]_, choosing a random proxy for load-balancing, and
-automatic fail-over to other hosts and proxies in case of network
-errors. Roaming clients can connect directly to the Stratum 1 service.
+network latency for the CernVM-FS clients, and they reduce the load for
+the Stratum 1 service. CernVM-FS supports WPAD/PAC proxy auto-configuration [Gauthier99]_,
+choosing a random proxy for load-balancing, and automatic fail-over to
+other hosts and proxies in case of network errors. Roaming clients can
+connect directly to the Stratum 1 service.
 
 IP Protocol Version
 ~~~~~~~~~~~~~~~~~~~
@@ -411,7 +411,7 @@ semicolon-separated list of known replica servers (enclose in quotes).
 The so defined URLs are organized as a ring buffer. Whenever download of
 files fails from a server, CernVM-FS automatically switches to the next
 mirror server. For repositories under the cern.ch domain, the Stratum 1
-servers are specified in /etc/cvmfs/domain.d/cern.ch.conf.
+servers are specified in ``/etc/cvmfs/domain.d/cern.ch.conf``.
 
 It is recommended to adjust the order of Stratum 1 servers so that the closest
 servers are used with priority. This can be done automatically by :ref:`using
@@ -422,12 +422,12 @@ automatically sorted according to round trip time by ``cvmfs_talk host probe``
 trip time measurement.
 
 The special sequence ``@fqrn@`` in the ``CVMFS_SERVER_URL`` string is
-replaced by fully qualified repository name (atlas.cern.cn, cms.cern.ch,
+replaced by fully qualified repository name (atlas.cern.ch, cms.cern.ch,
 ...). That allows to use the same parameter for many repositories hosted
 under the same domain. For instance,
-http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@ can resolve to
-http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch,
-http://cvmfs-stratum-one.cern.ch/cvmfs/cms.cern.ch, and so on depending
+``http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@`` can resolve to
+``http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch``,
+``http://cvmfs-stratum-one.cern.ch/cvmfs/cms.cern.ch``, and so on depending
 on the repository that is being mounted. The same works for the sequence
 ``@org@`` which is replaced by the unqualified repository name (atlas,
 cms, ...).
@@ -435,21 +435,21 @@ cms, ...).
 Proxy Lists
 ~~~~~~~~~~~
 
-CernVM-FS uses a dedicated HTTP proxy configuration, independent from
+CernVM-FS uses a dedicated HTTP proxy configuration, independent of
 system-wide settings. Instead of a single proxy, CernVM-FS uses a *chain
 of load-balanced proxy groups*. The CernVM-FS proxies are set by the
 ``CVMFS_HTTP_PROXY`` parameter.
 
 Proxy groups are used for load-balancing among several proxies of equal
-priority.  Starting with the first group, one proxy within a group is selected
-at random.  By default, this randomly selected proxy will used for all requests.
+priority. Starting with the first group, one proxy within a group is selected
+at random. By default, this randomly selected proxy will be used for all requests.
 If :ref:`proxy sharding <sct_proxy_sharding>` is enabled, then the proxy is
 instead selected on a per-request basis to distribute the requests across all
 proxies within the current group.
 
 If a proxy fails, CernVM-FS automatically switches to another proxy from the
-current group.  If all proxies in a group have failed, CernVM-FS switches to the
-next proxy group.  After probing the last proxy group in the chain, the first is
+current group. If all proxies in a group have failed, CernVM-FS switches to the
+next proxy group. After probing the last proxy group in the chain, the first is
 probed again. To avoid endless loops, for each file download the number of
 switches is limited by the total number of proxies.
 
@@ -460,7 +460,7 @@ In the case of proxies that use a DNS *round-robin* entry, wherein a single host
 resolves to multiple IP addresses, CVMFS automatically internally transforms the name
 into a load-balanced group, so you should use the host name and a semicolon.
 In order to limit the number of individual proxy servers used in
-a round-robin DNS entry, set ``CVMFS_MAX_IPADDR_PER_PROXY``.  This can also limit
+a round-robin DNS entry, set ``CVMFS_MAX_IPADDR_PER_PROXY``. This can also limit
 the perceived "hang duration" while CernVM-FS performs fail-overs.
 
 The ``DIRECT`` keyword for a hostname avoids using a proxy altogether. Note that
@@ -474,7 +474,7 @@ and potentially other proxy groups listed after that for backup. In order to
 prevent CernVM-FS from permanently using the backup proxies after a
 fail-over, CernVM-FS will automatically retry the first proxy group in the list
 after some time. The delay for re-trying is set in seconds by ``CVMFS_PROXY_RESET_AFTER``.
-This reset behaviour can be disabled by setting this parameter to 0.
+This reset behavior can be disabled by setting this parameter to 0.
 
 Proxy List Examples
 ^^^^^^^^^^^^^^^^^^^
@@ -503,8 +503,8 @@ according to the proxy server specification loaded from a PAC file. PAC
 files can be on a file system or accessible via HTTP. CernVM-FS looks
 for PAC files in the order given by the semicolon separated URLs in the
 ``CVMFS_PAC_URLS`` environment variable. This variable defaults to
-http://wpad/wpad.dat. The ``auto`` keyword used as a URL in
-``CVMFS_PAC_URLS`` is resolved to http://wpad/wpad.dat, too, in order to
+``http://wpad/wpad.dat``. The ``auto`` keyword used as a URL in
+``CVMFS_PAC_URLS`` is resolved to ``http://wpad/wpad.dat``, too, in order to
 be compatible with Frontier [Blumenfeld08]_.
 
 Fallback Proxy List
@@ -516,7 +516,7 @@ of both lists is the same. The fallback proxy list is appended to the
 regular proxy list, and if the fallback proxy list is set, any DIRECT is
 removed from both lists. The automatic proxy configuration of the
 previous section only sets the regular proxy list, not the fallback
-proxy list. Also the fallback proxy list can be automatically reordered;
+proxy list. Also, the fallback proxy list can be automatically reordered;
 see the next section.
 
 .. _sct_geoapi:
@@ -526,7 +526,7 @@ Ordering of Servers according to Geographic Proximity
 
 CernVM-FS Stratum 1 servers provide a RESTful service for geographic
 ordering. Clients can request
-`http://<HOST>/cvmfs/<FQRN>/api/v1.0/geo/<proxy\_address>/<server\_list>`
+``http://<HOST>/cvmfs/<FQRN>/api/v1.0/geo/<proxy_address>/<server_list>``.
 The proxy address can be replaced by a UUID if no proxies are used, and
 the CernVM-FS client does that if there are no regular proxies. The
 server list is comma-separated. The result is an ordered list of indexes
@@ -549,24 +549,24 @@ can be adjusted with the ``CVMFS_LOW_SPEED_LIMIT`` parameter. A very
 slow download is treated like a broken connection.
 
 On timeout errors and on connection failures (but not on name resolving
-failures), CernVM-FS will retry the path using an exponential backoff.
+failures), CernVM-FS will retry the path using an exponential backoff algorithm.
 This introduces a jitter in case there are many concurrent requests by a
 cluster of nodes, allowing a proxy server or web server to serve all the
 nodes consecutively. ``CVMFS_MAX_RETRIES`` sets the number of retries on
 a given path before CernVM-FS tries to switch to another proxy or host.
 The overall number of requests with a given proxy/host combination is
 ``$CVMFS_MAX_RETRIES``\ +1. ``CVMFS_BACKOFF_INIT`` sets the maximum
-initial backoff in seconds. The actual initial backoff is picked with
+initial backoff (time) in seconds. The actual initial backoff is picked with
 milliseconds precision randomly in the interval
-:math:`[1, \text{\$CVMFS\_BACKOFF\_INIT}\cdot 1000]`. With every retry,
+:math:`[1, \text{\$CVMFS_BACKOFF_INIT}\cdot 1000]`. With every retry,
 the backoff is then doubled.
 
 DNS Nameserver Changes
 ~~~~~~~~~~~~~~~~~~~~~~
 
-CernVM-FS can watch /etc/resolv.conf and automatically follow changes to the
+CernVM-FS can watch ``/etc/resolv.conf`` and automatically follow changes to the
 DNS servers. This behavior is controlled by the ``CVMFS_DNS_ROAMING`` client
-configuration. It is by default turned on on macOS and turned off on Linux.
+configuration. It is by default turned on macOS and turned off on Linux.
 
 
 Network Path Selection
@@ -601,15 +601,15 @@ Proxy Sharding
 ^^^^^^^^^^^^^^
 
 In the default (non-sharded) configuration, each CernVM-FS client will
-independently choose a single proxy to be used for all requests.  For sites with
+independently choose a single proxy to be used for all requests. For sites with
 many clients that are likely to access the same content, this can result in
 unnecessary duplication of cached content across multiple proxies.
 
 If proxy sharding is enabled via the ``CVMFS_PROXY_SHARD`` parameter, all
-proxies within a load-balancing group are used concurrently.  Each proxy handles
-a subset of the requests.  Proxies are selected using consistent hashing so that
+proxies within a load-balancing group are used concurrently. Each proxy handles
+a subset of the requests. Proxies are selected using consistent hashing so that
 multiple clients will independently select the same proxy for a given request,
-to maximise cache efficiency.  If any proxy fails, CernVM-FS automatically
+to maximize cache efficiency. If any proxy fails, CernVM-FS automatically
 removes it from the load-balancing group and distributes its requests evenly
 across the remaining proxies.
 
@@ -628,9 +628,9 @@ the host or by the proxy.
 * Explicit proxy errors (indicated via the `X-Squid-Error` or `Proxy-Status`
   headers) will always be classified as proxy failure.
 
-If CernVM-FS detects a host failure, it will fail-over to the next host in the
+If CernVM-FS detects a host failure, it will fail over to the next host in the
 list while keeping the proxy server untouched. If it detects a proxy failure, it
-will fail-over to to another proxy while keeping the host untouched. CernVM-FS
+will fail over to another proxy while keeping the host untouched. CernVM-FS
 will try all proxies of the current load-balance group in random order before
 trying proxies from the next load-balance group.
 
@@ -665,7 +665,7 @@ a working network path.
 Retry and Backoff
 ^^^^^^^^^^^^^^^^^
 
-On connection and timeout errors, CernVM-FS retries a fixed, limitied number of
+On connection and timeout errors, CernVM-FS retries a fixed, limited number of
 times on the same network path before performing a fail-over. Retrying involves
 an exponential backoff with a minimum and maximum waiting time.
 
@@ -688,8 +688,8 @@ Default Values
 * Maximum waiting time on a retry: 10 seconds (adjustable by CVMFS_BACKOFF_MAX)
 * Minimum/Maximum DNS name cache: 1 minute / 1 day
 
-**Note:** a continuous transfer rate below 1kB/s is treated like a network
-timeout.
+.. note::
+    A continuous transfer rate below 1 kB/s is treated like a network timeout.
 
 .. _sct_cache:
 
@@ -699,7 +699,7 @@ Cache Settings
 Downloaded files will be stored in a local cache directory. The
 CernVM-FS cache has a soft quota; as a safety margin, the partition
 hosting the cache should provide more space than the soft quota limit;
-we recommend to leave at least 20% + 1GB.
+we recommend to leave at least 20% + 1 GB.
 
 Once the quota limit is reached, CernVM-FS will automatically remove
 files from the cache according to the least recently used policy.
@@ -718,7 +718,7 @@ location of the cache directory can be set by ``CVMFS_CACHE_BASE``.
 On SELinux enabled systems, the cache directory and its content need to
 be labeled as ``cvmfs_cache_t``. During the installation of
 CernVM-FS RPMs, this label is set for the default cache directory
-/var/lib/cvmfs. For other directories, the label needs to be set
+``/var/lib/cvmfs``. For other directories, the label needs to be set
 manually by ``chcon -Rv --type=cvmfs_cache_t $CVMFS_CACHE_BASE``.
 
 Each repository can either have an exclusive cache or join the
@@ -729,6 +729,8 @@ directory should be at least the maximum of the recommended limits of
 its participating repositories. In order to have a repository not join
 the shared cache but use an exclusive cache, set
 ``CVMFS_SHARED_CACHE=no``.
+
+.. _alien cache:
 
 Alien Cache
 ~~~~~~~~~~~
@@ -744,7 +746,7 @@ The alien cache directory is set by the ``CVMFS_ALIEN_CACHE`` option. It
 can be located anywhere including cluster and network file systems. If
 configured, all data chunks are stored there. CernVM-FS ensures atomic
 access to the cache directory. It is safe to have the alien directory
-shared by multiple CernVM-FS processes and it is safe to unlink files
+shared by multiple CernVM-FS processes, and it is safe to unlink files
 from the alien cache directory anytime. The contents of files, however,
 must not be touched by third-party programs.
 
@@ -783,7 +785,7 @@ instances replace the local cache directory. Since the local cache directory is
 also used to store transient special files, ``CVMFS_WORKSPACE=$local_path``
 must be used when advanced cache configuration is used.
 
-A concrete cache manager instance has a user-defined name and it is specified
+A concrete cache manager instance has a user-defined name, and it is specified
 like
 
 ::
@@ -791,7 +793,7 @@ like
     CVMFS_CACHE_PRIMARY=myInstanceName
     CVMFS_CACHE_myInstanceName_TYPE=posix
 
-Multiple instances can thus be safely defined with different names but only one
+Multiple instances can thus be safely defined with different names, but only one
 is selected when the client boots. The following table lists the valid cache
 manager instance types.
 
@@ -804,7 +806,7 @@ external    Uses an external cache plugin process (see Section :ref:`cpt_plugins
 =========== ======================================================================
 
 The instance name "default" is blocked because the regular cache configuration
-syntax is automatically mapped to ``CVMFS_CACHE_default_...`` parameters.  The
+syntax is automatically mapped to ``CVMFS_CACHE_default_...`` parameters. The
 command ``sudo cvmfs_talk cache instance`` can be used to show the currently
 used cache manager instance.
 
@@ -813,10 +815,10 @@ Tiered Cache
 ^^^^^^^^^^^^
 
 The tiered cache manager combines two other cache manager instances as an upper
-layer and a lower layer into a single functional cache manager.  Usually, a
+layer and a lower layer into a single functional cache manager. Usually, a
 small and fast upper layer (SSD, memory) is combined with a larger and slower
 lower layer (HDD, network drive). The upper layer needs to be large enough to
-serve all currently open files.  On an upper layer cache miss, CernVM-FS tries
+serve all currently open files. On an upper layer cache miss, CernVM-FS tries
 to copy the missing object from the lower into the upper layer. On a lower layer
 cache miss, CernVM-FS download and stores objects either in both layers or in
 the upper layer only, depending on the configuration.
@@ -903,7 +905,7 @@ NFS Server Mode
 
 In case there is no local hard disk space available on a cluster of
 worker nodes, a single CernVM-FS client can be exported via
-nfs [Callaghan95]_ [Shepler03]_ to these worker nodes.This mode of deployment
+nfs [Callaghan95]_ [Shepler03]_ to these worker nodes. This mode of deployment
 will inevitably introduce a performance bottleneck and a single point of
 failure and should be only used if necessary.
 
@@ -914,15 +916,15 @@ support, set ``CVMFS_NFS_SOURCE=yes``. On the client side, all available nfs
 implementations should work.
 
 In the NFS mode, upon mount an additional directory
-nfs\_maps.$repository\_name appears in the CernVM-FS cache directory.
+``nfs_maps.$repository_name`` appears in the CernVM-FS cache directory.
 These *NFS maps* use leveldb to store the virtual inode CernVM-FS issues
 for any accessed path. The virtual inode may be requested by NFS clients
 anytime later. As the NFS server has no control over the lifetime of
 client caches, entries in the NFS maps cannot be removed.
 
 Typically, every entry in the NFS maps requires some 150-200 Bytes. A
-recursive ``find`` on /cvmfs/atlas.cern.ch with 50 million entries, for
-instance, would add up 8GB in the cache directory. For a CernVM-FS instance
+recursive ``find`` on ``/cvmfs/atlas.cern.ch`` with 50 million entries, for
+instance, would add up 8 GB in the cache directory. For a CernVM-FS instance
 that is exported via NFS, the safety margin for the NFS maps needs be
 taken into account. It also might be necessary to monitor the actual
 space consumption.
@@ -937,7 +939,7 @@ Tuning
 
 The default settings in CernVM-FS are tailored to the normal, non-NFS
 use case. For decent performance in the NFS deployment, the amount of
-memory given to the meta-data cache should be increased. By default,
+memory given to the metadata cache should be increased. By default,
 this is 16M. It can be increased, for instance, to 256M by setting
 ``CVMFS_MEMCACHE_SIZE`` to 256. Furthermore, the maximum number of
 download retries should be increased to at least 2.
@@ -945,33 +947,33 @@ download retries should be increased to at least 2.
 The number of NFS daemons should be increased as well. A value of 128
 NFS daemons has shown perform well. In Scientific Linux, the number of
 NFS daemons is set by the ``RPCNFSDCOUNT`` parameter in
-/etc/sysconfig/nfs.
+``/etc/sysconfig/nfs``.
 
 The performance will benefit from large RAM on the NFS server
-(:math:`\geq` 16GB) and CernVM-FS caches hosted on an SSD
+(:math:`\geq` 16 GB) and CernVM-FS caches hosted on an SSD
 hard drive.
 
 .. _sct_nfs_interleaved:
 
-Export of /cvmfs with Cray DVS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Export of ``/cvmfs`` with Cray DVS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On Cray DVS and possibly other systems that export /cvmfs as a whole instead of
+On Cray DVS and possibly other systems that export ``/cvmfs`` as a whole instead of
 individual repositories as separate volumes, an additional effort is needed to
 ensure that inodes are distinct from each other across multiple repositories.
 The ``CVMFS_NFS_INTERLEAVED_INODES`` parameter can be used to configure
 repositories to only issue inodes of a particular residue class. To ensure
 pairwise distinct inodes across repositories, each repository should be
-configured with a different residue class.  For instance, in order to avoid
+configured with a different residue class. For instance, in order to avoid
 inode clashes between the atlas.cern.ch and the cms.cern.ch repositories,
-there can be a configuration file /etc/cvmfs/config.d/atlas.cern.ch.local
+there can be a configuration file ``/etc/cvmfs/config.d/atlas.cern.ch.local``
 with
 
 ::
 
     CVMFS_NFS_INTERLEAVED_INODES=0%2 # issue inodes 0, 2, 4, ...
 
-and a configuration file /etc/cvmfs/config.d/cms.cern.ch.local with
+and a configuration file ``/etc/cvmfs/config.d/cms.cern.ch.local`` with
 
 ::
 
@@ -990,7 +992,7 @@ As an alternative to the existing, `leveldb
 maps can optionally be managed out of the CernVM-FS cache directory by
 SQLite. This allows the NFS maps to be placed on shared storage and
 accessed by multiple CernVM-FS NFS export nodes simultaneously for
-clustering and active high-availablity setups. In order to enable shared
+clustering and active high-availability setups. In order to enable shared
 NFS maps, set ``CVMFS_NFS_SHARED`` to the path that should be used to
 host the SQLite database. If the path is on shared storage, the shared
 storage has to support POSIX file locks. The drawback of the
@@ -1021,15 +1023,15 @@ File Ownership
 --------------
 
 By default, cvmfs presents all files and directories as belonging to the
-mounting user, which for system mounts under /cvmfs is the user ``cvmfs``.
+mounting user, which for system mounts under ``/cvmfs`` is the user ``cvmfs``.
 Alternatively, CernVM-FS can present the uid and gid of file owners as they
 have been at the time of publication by setting ``CVMFS_CLAIM_OWNERSHIP=no``.
 
 If the real uid and gid values are shown, stable uid and gid values across nodes
-are recommended; otherwise the owners shown on clients can be confusing.  The
-client can also dynamically remap uid and gid values.  To do so, the parameters
+are recommended; otherwise the owners shown on clients can be confusing. The
+client can also dynamically remap uid and gid values. To do so, the parameters
 ``CVMFS_UID_MAP`` and ``CVMFS_GID_MAP`` should provide the path to text files
-that specify the mapping.  The format of the map files is identical to the map
+that specify the mapping. The format of the map files is identical to the map
 files used for :ref:`bulk changes of ownership on release manager machines <sct_repo_ownership>`.
 
 
@@ -1109,7 +1111,7 @@ repositories.
 cvmfs\_config
 ~~~~~~~~~~~~~
 
-The ``cvmfs_config`` utility provides commands in order to setup the
+The ``cvmfs_config`` utility provides commands in order to set up the
 system for use with CernVM-FS.
 
 **setup**
@@ -1119,11 +1121,11 @@ system for use with CernVM-FS.
 
 **chksetup**
     The ``chksetup`` command inspects the system and the
-    CernVM-FS configuration in /etc/cvmfs for common problems.
+    CernVM-FS configuration in ``/etc/cvmfs`` for common problems.
 
 **showconfig**
     The ``showconfig`` command prints the CernVM-FS parameters for all
-    repositories or for the specific repository given as argument.  With the
+    repositories or for the specific repository given as argument. With the
     `-s` option, only non-empty parameters are shown.
 
 **stat**
@@ -1132,11 +1134,11 @@ system for use with CernVM-FS.
 
 **status**
     The ``status`` command shows all currently mounted repositories and
-    the process id (PID) of the CernVM-FS processes managing a mount
+    the process ID (PID) of the CernVM-FS processes managing a mount
     point.
 
 **probe**
-    The ``probe`` command tries to access /cvmfs/$repository for all
+    The ``probe`` command tries to access ``/cvmfs/$repository`` for all
     repositories specified in ``CVMFS_REPOSITORIES`` or the ones specified as
     a space separated list on the command line, respectively.
 
@@ -1162,9 +1164,9 @@ system for use with CernVM-FS.
 
 **killall**
     The ``killall`` command immediately unmounts all repositories under
-    /cvmfs and terminates the associated processes.  It is meant to escape from
-    a hung state without the need to reboot a machine.  However, all processes
-    that use CernVM-FS at the time will be terminated, too.  The need to use
+    ``/cvmfs`` and terminates the associated processes. It is meant to escape from
+    a hung state without the need to reboot a machine. However, all processes
+    that use CernVM-FS at the time will be terminated, too. The need to use
     this command very likely points to a network problem or a bug in cvmfs.
 
 **bugreport**
@@ -1185,14 +1187,14 @@ be of particular interest though.
 
       cvmfs_talk cleanup 0
 
-will, without interruption of service, immediately cleanup the cache
+will, without interruption of service, immediately clean up the cache
 from all files that are not currently pinned in the cache.
 
 ::
 
       cvmfs_talk cleanup rate 120
 
-shows the number of cache cleanups in the last two hours (120 minutes).  If
+shows the number of cache cleanups in the last two hours (120 minutes). If
 this value is larger than one or two, the cache size is probably two small and
 the client experiences cache thrashing.
 
@@ -1218,7 +1220,7 @@ Information about the current cache usage can be gathered using the
 ``df`` utility. For repositories created with the CernVM-FS 2.1
 toolchain, information about the overall number of file system entries
 in the repository as well as the number of entries covered by currently
-loaded meta-data can be gathered by ``df -i``.
+loaded metadata can be gathered by ``df -i``.
 
 For the `Nagios monitoring system <http://www.nagios.org>`_ [Schubert08]_, a
 checker plugin is available `on our website

--- a/cpt-containers.rst
+++ b/cpt-containers.rst
@@ -5,12 +5,12 @@ Container Images and CernVM-FS
 
 CernVM-FS interacts with container technologies in two main ways:
 
-1. CernVM-FS application repositories (e.g. /cvmfs/atlas.cern.ch) can be mounted into a stock container (e.g. CentOS 8)
-2. The container root filesystem (e.g. the root file system "/" of CentOS 8) itself can be served directly from CernVM-FS
+1. CernVM-FS application repositories (e.g. ``/cvmfs/atlas.cern.ch``) can be mounted into a stock container (e.g. CentOS 8)
+2. The container root file system (e.g. the root file system ``/`` of CentOS 8) itself can be served directly from CernVM-FS
 
 Both ways have a similar goal, that is to give users access to a reproducible,
 ready-to-use environment while retaining the advantages of CernVM-FS regarding
-data distribution, content de-duplication, software preservation and ease of
+data distribution, content deduplication, software preservation and ease of
 operations.
 
 Mounting ``/cvmfs`` inside a container
@@ -78,7 +78,7 @@ A similar approach is possible with apptainer, but the syntax is a little differ
 
 
 Also in apptainer it is possible to use the syntax
-``host_directory:container_directory`` and it is possible to mount multiple
+``host_directory:container_directory``, and it is possible to mount multiple
 paths at the same time separating the ``--bind`` arguments with a comma.
 
 ::
@@ -90,8 +90,8 @@ paths at the same time separating the ``--bind`` arguments with a comma.
     drwxrwxr-x  4      125      130    6 Nov 16  2010 lhcb.cern.ch/
 
 
-For Kubernetes, the approach is more heterogeneous and it depends on the cluster settings.
-A recommended approach is creating a DaemonSet so that on every node one pod exposes /cvmfs to other pods.
+For Kubernetes, the approach is more heterogeneous, and it depends on the cluster settings.
+A recommended approach is creating a DaemonSet so that on every node one pod exposes ``/cvmfs`` to other pods.
 This pod may use the cvmfs service container.
 
 Alternatively, a `CSI-plugin <https://clouddocs.web.cern.ch/containers/tutorials/cvmfs.html#kubernetes>`_
@@ -103,7 +103,7 @@ Distributing container images on CernVM-FS
 ------------------------------------------
 
 Image distribution on CernVM-FS works with *unpacked* layers or image root
-file systems.  Any CernVM-FS repository can store container images.
+file systems. Any CernVM-FS repository can store container images.
 
 A number of images are already provided in ``/cvmfs/unpacked.cern.ch``, a
 repository managed at CERN to host container images for various purposes and
@@ -113,9 +113,9 @@ publish images from registries on CernVM-FS.
 Every container image is stored in two forms on CernVM-FS
 
 1. All the unpacked layers of the image
-2. The whole unpacked root filesystem of the image
+2. The whole unpacked root file system of the image
 
-With the whole filesystem root directory in /cvmfs, ``apptainer`` can directly start a container.
+With the whole file system root directory in ``/cvmfs``, ``apptainer`` can directly start a container.
 
 ::
 
@@ -123,7 +123,7 @@ With the whole filesystem root directory in /cvmfs, ``apptainer`` can directly s
 
 The layers can be used, e.g., with containerd and the CernVM-FS snapshotter.
 In addition, the container tools create the *chains* of an image.
-Chains are partial root filesystem directores where layers are applied one after another.
+Chains are partial root file system directories where layers are applied one after another.
 This is used internally to incrementally publish image updates if only a subset of layers changed.
 
 Using unpacked.cern.ch
@@ -131,7 +131,7 @@ Using unpacked.cern.ch
 
 The ``unpacked.cern.ch`` repository provides a centrally managed container
 image hub without burdening users with managing their CernVM-FS repositories
-or conversion of images.  It also enables saving storage space because
+or conversion of images. It also enables saving storage space because
 of cvmfs deduplication of files that are common between different images.
 The repository is publicly available.
 
@@ -142,7 +142,7 @@ of the following two files, the so-called *wishlists*.
 2. https://github.com/cvmfs/images-unpacked.cern.ch/blob/master/recipe.yaml
 
 The first file is accessible from CERN infrastructure, while the second is on
-Github open to everybody.
+GitHub open to everybody.
 
 A simple pull request against one of those files is sufficient, the image is
 vetted, and the pull request merged. Soon after the pull request is merged DUCC
@@ -211,9 +211,9 @@ As soon as a new or modified container image is detected it starts the conversio
 
 CernVM-FS integration with ``containerd`` is achieved by the cvmfs snapshotter plugin,
 a specialized component responsible for assembling all the layers of container
-images into a stacked filesystem that ``containerd`` can use.
+images into a stacked file system that ``containerd`` can use.
 The snapshotter takes as input the list of required layers and outputs a directory
-containing the final filesystem. It is also responsible to clean-up the output
+containing the final file system. It is also responsible to clean up the output
 directory when containers using it are stopped.
 
 How to use the CernVM-FS Snapshotter
@@ -225,7 +225,7 @@ The default socket is ``/run/containerd-cvmfs-grpc/containerd-cvmfs-grpc.sock``.
 This socket is created automatically by the snapshotter if it does not exist.
 
 The containerd snapshotter is available from http://ecsft.cern.ch/dist/cvmfs/snapshotter/.
-Packages will be made available in future.
+Packages will be made available in the future.
 
 The binary accepts the following command line options:
 
@@ -265,9 +265,9 @@ Note that if only the repository is specified under the key value ``repository``
 ``podman`` integration (pre-production)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to use images from unpacked.cern.ch with podman,
-the podman client needs to point to an *image store* that references the images on /cvmfs.
-The image store is a directory is a directory with a a certain file structure
+In order to use images from ``unpacked.cern.ch`` with podman,
+the podman client needs to point to an *image store* that references the images on ``/cvmfs``.
+The image store is a directory is a directory with a certain file structure
 that provides an index of images and layers.
 The CernVM-FS container tools by default create a podman image store for published images.
 
@@ -288,7 +288,8 @@ In order to set the image store, edit ``/etc/containers/storage.conf`` or ``${HO
 
 The configuration can be checked with the ``podman images`` command.
 
-**Note:** the image store in the unpacked.cern.ch repository currently provides access only to test images.
-This is due to poor performance in the image conversion when the image store is updated.
-This will be fixed in a future version.
+.. note::
+    The image store in the ``unpacked.cern.ch`` repository currently provides access only to test images.
+    This is due to poor performance in the image conversion when the image store is updated.
+    This will be fixed in a future version.
 

--- a/cpt-details.rst
+++ b/cpt-details.rst
@@ -21,7 +21,7 @@ File Catalog
 ------------
 
 A CernVM-FS repository is defined by its *file catalog*. The file
-catalog is an `SQLite database <https://www.sqlite.org>`_ [Allen10]_
+catalog is a `SQLite database <https://www.sqlite.org>`_ [Allen10]_
 having a single table that lists files and directories together with
 its metadata. The table layout is shown in the table below:
 
@@ -45,24 +45,24 @@ gid                     Integer
 xattr                   BLOB
 ====================== ================
 
-In order to save space we do not store absolute paths. Instead we
+In order to save space we do not store absolute paths. Instead, we
 store MD5 [Rivest92]_, [Turner11]_ hash values of the absolute path
 names. Symbolic links are kept in the catalog. Symbolic links may
 contain environment variables in the form ``$(VAR_NAME)`` or
 ``$(VAR_NAME:-/default/path)`` that will be dynamically resolved by
-CernVM-FS on access. Hardlinks are emulated by CernVM-FS. The hardlink
-count is stored in the lower 32 bits of the hardlinks field, and a *hardlink
-group* is stored in the higher 32 bits. If the hardlink group is
-greater than zero, all files with the same hardlink group will get the
-same inode issued by the CernVM-FS Fuse client. The emulated hardlinks
+CernVM-FS on access. Hard links are emulated by CernVM-FS. The hard link
+count is stored in the lower 32 bits of the hard links field, and a *hard link
+group* is stored in the higher 32 bits. If the hard link group is
+greater than zero, all files with the same hard link group will get the
+same inode issued by the CernVM-FS Fuse client. The emulated hard links
 work within the same directory, only. The cryptographic content hash
 refers to the zlib-compressed [Deutsch96]_ version of the file. Flags
-indicate the type of an directory entry (see table :ref:`below
+indicate the type of directory entry (see table :ref:`below
 <tab_dirent_flags>`).
 
-Extended attributes are either NULL or stored as a BLOB of key-value pairs.  It
+Extended attributes are either NULL or stored as a BLOB of key-value pairs. It
 starts with 8 bytes for the data structure's version (currently 1) followed by
-8 bytes for the number of extended attributes.  This is followed by the list of
+8 bytes for the number of extended attributes. This is followed by the list of
 pairs, which start with two 8 byte values for the length of the key/value
 followed by the concatenated strings of the key and the value.
 
@@ -80,7 +80,7 @@ followed by the concatenated strings of the key and the value.
 ============ ====================================
 
 As of bit 8, the flags store the cryptographic content hash
-algorithm used to process the given file.  Bit 11 is 1 if the file is
+algorithm used to process the given file. Bit 11 is 1 if the file is
 stored uncompressed.
 
 A file catalog contains a *time to live* (TTL), stored in seconds. The
@@ -89,7 +89,7 @@ when expired. Checking for a new catalog version takes place with the
 first file system operation on a CernVM-FS volume after the TTL has
 expired. The default TTL is 4 minutes. If a new catalog is available,
 CernVM-FS delays the loading for the period of the CernVM-FS kernel
-cache life time (default: 1 minute). During this drain-out period, the
+cache lifetime (default: 1 minute). During this drain-out period, the
 kernel caching is turned off. The first file system operation on a
 CernVM-FS volume after that additional delay will apply a new file
 catalog and kernel caching is turned back on.
@@ -148,13 +148,13 @@ A CernVM-FS file catalog maintains several counters about its contents
 and the contents of all of its nested catalogs. The idea is that the
 catalogs know how many entries there are in their sub catalogs even
 without opening them. This way, one can immediately tell how many
-entries, for instance, the entire ATLAS repository has. Some of the
+entries, for instance, the entire ATLAS repository has. Some
 numbers are shown using the number of inodes in ``statvfs``. So
 ``df -i`` shows the overall number of entries in the repository and (as
 number of used inodes) the number of entries of currently loaded
 catalogs. Nested catalogs create an additional entry (the transition
 directory is stored in both the parent and the child catalog). File
-hardlinks are still individual entries (inodes) in the cvmfs catalogs.
+hard links are still individual entries (inodes) in the cvmfs catalogs.
 The following counters are maintained for both a catalog itself and for
 the subtree this catalog is root of:
 
@@ -184,7 +184,7 @@ serves as entry point into the repository's catalog structure. The
 repository manifest is the first file accessed by the CernVM-FS client
 at mount time and therefore must be accessible via HTTP on the
 repository root URL. It is always called **.cvmfspublished** and
-contains fundamental repository meta data like the root catalog's
+contains fundamental repository metadata like the root catalog's
 cryptographic hash and the repository revision number as a key-value
 list.
 
@@ -194,7 +194,7 @@ Internal Manifest Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Below is an example of a typical manifest file. Each line starts with a
-capital letter specifying the meta data field, followed by the actual data
+capital letter specifying the metadata field, followed by the actual data
 string. The list of meta information is ended by a separator line (``--``)
 followed by signature information further described :ref:`here
 <sct_cvmfspublished_signature>`.
@@ -215,14 +215,14 @@ followed by signature information further described :ref:`here
 
 Please refer to
 table below for detailed information about each of the
-meta data fields.
+metadata fields.
 
 .. |br| raw:: html
 
    <br />
 
 +-----------+-------------------------------------------------------------+
-| **Field** | **Meta Data Description**                                   |
+| **Field** | **Metadata Description**                                    |
 +-----------+-------------------------------------------------------------+
 | ``C``     | Cryptographic hash of the repository's current root catalog |
 +-----------+-------------------------------------------------------------+
@@ -284,7 +284,7 @@ of the repository.
 The top level hash used for the repository signature can be found in the
 repository manifest right below the separator line (``--`` /
 :ref:`see above <sct_manifeststructure>`).
-It is the cryptographic hash of the manifest's meta data lines excluding
+It is the cryptographic hash of the manifest's metadata lines excluding
 the separator line. Following the top level hash is the actual signature
 produced by the X.509 certificate signing procedure in binary form.
 
@@ -308,7 +308,7 @@ Blacklisting
 ^^^^^^^^^^^^
 
 In addition to validating the white-list, CernVM-FS checks certificate
-fingerprints against the local black-list /etc/cvmfs/blacklist and the
+fingerprints against the local black-list ``/etc/cvmfs/blacklist`` and the
 blacklist in an optional :ref:`"Config Repository" <sct_config_repository>`.
 The blacklisted fingerprints have to be in the same format as the
 fingerprints on the white-list. The black-list has precedence over the
@@ -318,10 +318,10 @@ Blacklisted fingerprints prevent clients from loading future
 repository publications by a corresponding compromised repository key,
 but they do not prevent mounting a repository revision that had
 previously been mounted on a client, because the catalog for that
-revision is already in the cache.  However, the same blacklist files
+revision is already in the cache. However, the same blacklist files
 also support another format that actively blocks revisions associated
 with a compromised repository key from being mounted and even forces
-them to be unmounted if they are mounted.  The format for that is a
+them to be unmounted if they are mounted. The format for that is a
 less-than sign followed by the repository name followed by a blank and
 a repository revision number:
 
@@ -330,7 +330,7 @@ a repository revision number:
         <repository.name NNN
 
 This will prevent all revisions of a repository called repository.name
-less than the number NNN from being mounted or staying mounted.  An
+less than the number NNN from being mounted or staying mounted. An
 effective protection against a compromised repository key will use
 both this format to prevent mounts and the fingerprint format to
 prevent accepting future untrustworthy publications signed by the
@@ -344,7 +344,7 @@ the performance and usability of CernVM-FS. If possible, CernVM-FS tries
 to benefit from the HTTP/1.1 features keep-alive and cache-control.
 Internally, CernVM-FS uses the `libcurl library <http://curl.haxx.se/libcurl>`_.
 
-The HTTP behaviour affects a system with cold caches only. As soon as
+The HTTP behavior affects a system with cold caches only. As soon as
 all necessary files are cached, there is only network traffic when a
 catalog TTL expires. The CernVM-FS download manager runs as a separate
 thread that handles download requests asynchronously in parallel.
@@ -370,7 +370,7 @@ high latency networks we suffer from the bare number of requests: Each
 request-response cycle has a penalty of at least the network round trip
 time. Using plain HTTP/1.0, this results in at least
 :math:`3\cdot\text{round trip time}` additional running time per file
-download for TCP handshake, HTTP GET, and TCP connection finalisation.
+download for TCP handshake, HTTP GET, and TCP connection finalization.
 By including the ``Connection: Keep-Alive`` header into HTTP requests,
 we advise the HTTP server end to keep the underlying TCP connection
 opened. This way, overhead ideally drops to just round trip time for a
@@ -392,9 +392,9 @@ Cache Control
 ~~~~~~~~~~~~~
 
 In a limited way, CernVM-FS advises intermediate web caches how to
-handle its requests. Therefore it uses the ``Pragma: no-cache`` and the
+handle its requests. Therefore, it uses the ``Pragma: no-cache`` and the
 ``Cache-Control: no-cache`` headers in certain cases. These cache
-control headers apply to both, forward proxies as well as reverse
+control headers apply to both, forward proxies and reverse
 proxies. This is not a guarantee that intermediate proxies fetch a fresh
 original copy (though they should).
 
@@ -454,12 +454,12 @@ environment variable is set, CernVM-FS does not try to resolve IPv6
 records.
 
 The timeout for name resolving is hard-coded to 2 attempts with a
-timeout of 3 seconds each. This is independent from the
+timeout of 3 seconds each. This is independent of the
 ``CVMFS_TIMEOUT`` and ``CVMFS_TIMEOUT_DIRECT`` settings. The effective
 timeout can be a bit longer than 6 seconds because of a backoff.
 
 The name server used by CernVM-FS is looked up only once on start. If
-the name server changes during the life time of a CernVM-FS mount point,
+the name server changes during the lifetime of a CernVM-FS mount point,
 this change needs to be manually advertised to CernVM-FS using
 ``cvmfs_talk nameserver set``.
 
@@ -487,13 +487,13 @@ Pinned                            Integer
 File type (chunk or file catalog) Integer
 ================================= =========================
 
-CernVM-FS does not strictly enforce the cache limit. Instead
+CernVM-FS does not strictly enforce the cache limit. Instead,
 CernVM-FS works with two customizable soft limits, the *cache quota* and
 the *cache threshold*. When exceeding the cache quota, files are deleted
 until the overall cache size is less than or equal to the cache
 threshold. The cache threshold is currently hard-wired to half of the
 cache quota. The cache quota is for data files as well as file catalogs.
-Currently loaded catalogs are pinned in the cache, they will not be
+Currently, loaded catalogs are pinned in the cache, they will not be
 deleted until unmount or until a new repository revision is applied. On
 unmount, pinned file catalogs are updated with the highest sequence
 number. As a pre-caution against a cache that is blocked by pinned
@@ -529,7 +529,7 @@ automatically quits.
 
 The CernVM-FS cache supports two classes of files with respect to the
 cache replacement strategy: *normal* files and *volatile* files. The
-sequence numbers of volatile files have bit 63 set. Hence they are
+sequence numbers of volatile files have bit 63 set. Hence, they are
 interpreted as negative numbers and have precedence over normal files
 when it comes to cache cleanup. On automatic rebuild the volatile
 property of entries in the cache database is lost.
@@ -549,14 +549,14 @@ CernVM-FS memory consumption (currently :math:`\approx` 45 MB extra)
 and ensures consistency between remounts of CernVM-FS. The performance
 penalty for doing so is small. CernVM-FS uses `Google's leveldb
 <https://github.com/google/leveldb>`_, a fast, local key value store.
-Reads and writes are only performed when meta-data are looked up in
+Reads and writes are only performed when metadata are looked up in
 SQLite, in which case the SQLite query supposedly dominates the
 running time.
 
 A drawback of the NFS maps is that there is no easy way to account for
 them by the cache quota. They sum up to some 150-200 Bytes per path name
-that has been accessed. A recursive ``find`` on /cvmfs/atlas.cern.ch
-with 50 million entries, for instance, would add up 8GB in the cache
+that has been accessed. A recursive ``find`` on ``/cvmfs/atlas.cern.ch``
+with 50 million entries, for instance, would add up 8 GB in the cache
 directory. This is mitigated by the fact that the NFS mode will be only
 used on few servers that can be given large enough spare space on hard
 disk.
@@ -564,15 +564,15 @@ disk.
 Loader
 ------
 
-The CernVM-FS Fuse module comprises a minimal *loader* loader process
+The CernVM-FS Fuse module comprises a minimal *loader* process
 (the ``cvmfs2`` binary) and a shared library containing the actual
 Fuse module (``libcvmfs_fuse.so``, ``libcvmfs_fuse3.so``). This structure makes
 it possible to reload CernVM-FS code and parameters without unmounting the file
-system. Loader and library don't share any symbols except for two global structs
-``cvmfs_exports`` and ``loader_exports`` used to call each others
+system. Loader and library do not share any symbols except for two global structs
+``cvmfs_exports`` and ``loader_exports`` that are used to call each other's
 functions. The loader process opens the Fuse channel and implements stub
 Fuse callbacks that redirect all calls to the CernVM-FS shared library.
-Hotpatch is implemented as unloading and reloading of the shared
+Hotpatching is implemented as unloading and reloading of the shared
 library, while the loader temporarily queues all file system calls
 in-between. Among file system calls, the Fuse module has to keep very
 little state. The kernel caches are drained out before reloading. Open
@@ -604,7 +604,7 @@ getattr and lookup
 
 Requests for file attributes are entirely served from the mounted
 catalogs, there is no network traffic involved. This function is called
-as pre-requisite to other file system operations and therefore the most
+as prerequisite to other file system operations and therefore the most
 frequently called Fuse callback. In order to minimize relatively
 expensive SQLite queries, CernVM-FS uses a hash table to store negative
 and positive query results. The default size for this memory cache is
@@ -653,7 +653,7 @@ getxattr
 ~~~~~~~~
 
 CernVM-FS uses synthetic extended attributes to display additional repository
-information. In general they can be displayed with a command like
+information. In general, they can be displayed with a command like
 
 ::
 
@@ -671,14 +671,14 @@ There are the following supported magic attributes:
     Hashes and sizes of the chunks of a regular (large) file.
 
 **compression**
-    Compression algorithm, for regular files only.  Either "zlib" or "none".
+    Compression algorithm, for regular files only. Either "zlib" or "none".
 
 **expires**
-    Shows the remaining life time of the mounted root file catalog in
+    Shows the remaining lifetime of the mounted root file catalog in
     minutes.
 
 **external\_file**
-    Indicates if a regular file is an external file or not.  Either 0 or 1.
+    Indicates if a regular file is an external file or not. Either 0 or 1.
 
 **external\_host**
     Like ``host`` but for the host settings to fetch external files.
@@ -727,13 +727,13 @@ There are the following supported magic attributes:
     Shows the overall number of downloaded files since mounting.
 
 **nioerr**
-    Shows the total number of I/O errors encoutered since mounting.
+    Shows the total number of I/O errors encountered since mounting.
 
 **nopen**
     Shows the overall number of ``open()`` calls since mounting.
 
 **pid**
-    Shows the process id of the CernVM-FS Fuse process.
+    Shows the process ID of the CernVM-FS Fuse process.
 
 **proxy**
     Shows the currently active HTTP proxy.
@@ -793,10 +793,10 @@ of health and performance numbers.
 Repository Publishing
 ---------------------
 
-Repositories are not immutable, every now and then they get updated.
+Repositories are not immutable, periodically they get updated.
 This might be installation of a new release or a patch for an existing
 release. But, of course, each time only a small portion of the
-repository is touched, say out of . In order not to re-process an entire
+repository is touched. To prevent re-processing the entire
 repository on every update, we create a read-write file system interface
 to a CernVM-FS repository where all changes are written into a distinct
 scratch area.
@@ -818,8 +818,8 @@ first fully functional implementation has been presented by Wright et
 al. [Wright04]_. By now, union file systems are well established for
 "Live CD" builders, which use a RAM disk overlay on top of the read-only
 system partition in order to provide the illusion of a fully
-read-writable system. CernVM-FS supports both aufs and OverlayFS
-union file systems.
+read-writable system. CernVM-FS supports only the OverlayFS union file systems.
+It used to support ``aufs``, but no active support is provided for it anymore.
 
 Union file systems can be used to track changes on CernVM-FS repositories
 (Figure :ref:`below <fig_overlay>`). In this case, the read-only file system

--- a/cpt-ducc.rst
+++ b/cpt-ducc.rst
@@ -55,9 +55,9 @@ To uniquely identify an image, we need to provide:
 2. image repository
 3. image tag or image digest (or both)
 
-We use a slash (`/`) to separate the `registry` from the `repository`, a
-colon (`:`) to separate the `repository` from the `tag` and the at (`@`) to
-separate the `digest` from the tag or from the `repository`.  The syntax is
+We use a slash (``/``) to separate the `registry` from the `repository`, a
+colon (``:``) to separate the `repository` from the `tag` and the at (``@``) to
+separate the `digest` from the tag or from the `repository`. The syntax is
 
 ::
 
@@ -78,7 +78,7 @@ start.
 Image Wish List
 =================
 
-The user specifices the set of images supposed to be published on CernVM-FS
+The user specifies the set of images supposed to be published on CernVM-FS
 in the form of a wish list. The wish list consists of triplets of input image,
 the output thin image and the cvmfs destination repository for the unpacked
 data.
@@ -87,7 +87,7 @@ data.
 
     wish => (input_image, output_thin_image, cvmfs_repository)
 
-The input image in your wish should unambigously specify an image as decribed
+The input image in your wish should unambiguously specify an image as described
 above.
 
 
@@ -109,7 +109,7 @@ four images is show below.
         - 'https://registry.hub.docker.com/library/fedora:latest'
         - 'https://registry.hub.docker.com/library/debian:stable'
 
-**version**: wish list version; at the moment only `1` is supported.
+**version**: wish list version; at the moment only ``1`` is supported.
 
 **user**: the account that will push the thin images into the docker registry.
 The password must be stored in the ``DOCKER2CVMFS_DOCKER_REGISTRY_PASS``
@@ -121,18 +121,18 @@ flat root file systems.
 **output_format**: how to name the thin images. It accepts a few variables that
 refer to the input image.
 
-* $(scheme), the image url protocol, most likely `http` or `https`
+* ``$(scheme)``, the image url protocol, most likely ``http`` or ``https``
 
-* $(registry), the Docker registry of the input image, in the case of the
-  example it would be `registry.hub.docker.com`
+* ``$(registry)``, the Docker registry of the input image, in the case of the
+  example it would be ``registry.hub.docker.com``
 
-* $(repository), the image repository of the input image, like
-  `library/ubuntu` or `atlas/athena`
+* ``$(repository)``, the image repository of the input image, like
+  ``library/ubuntu`` or ``atlas/athena``
 
-* $(tag), the tag of the image, which could be `latest`, `stable` or
-  `v0.1.4`
+* ``$(tag)``, the tag of the image, which could be ``latest``, ``stable`` or
+  ``v0.1.4``
 
-* $(image), combines $(repository) and $(tag)
+* ``$(image)``, combines ``$(repository)`` and ``$(tag)``
 
 **input**: list of docker images to convert
 
@@ -147,14 +147,14 @@ DUCC supports the following commands.
 convert
 *******
 
-The `convert` command provides the core functionality of DUCC:
+The ``convert`` command provides the core functionality of DUCC:
 
 ::
 
     cvmfs_ducc convert wishlist.yaml
 
 
-where `wishlist.yaml` is the path of a wish list file.
+where ``wishlist.yaml`` is the path of a wish list file.
 
 This command will try to ingest all the specified images into CernVM-FS.
 
@@ -164,13 +164,13 @@ creating the flat root file system necessary to work with Singularity and
 writing DUCC specific metadata in the CernVM-FS repository next to the unpacked
 image data.
 
-The layers are stored in the `.layer` subdirectory in the CernVM-FS repository,
-while the flat root file systems are stored in the `.flat` subdirectory.
+The layers are stored in the ``.layer`` subdirectory in the CernVM-FS repository,
+while the flat root file systems are stored in the ``.flat`` subdirectory.
 
 loop
 ****
 
-The `loop` command continously executes the `convert` command. On each
+The ``loop`` command continuously executes the ``convert`` command. On each
 iteration, the wish list file is read again in order to pick up changes.
 
 ::
@@ -180,7 +180,7 @@ iteration, the wish list file is read again in order to pick up changes.
 convert-single-image
 ********************
 
-The `convert-single-image` command is useful when only a single image need to
+The ``convert-single-image`` command is useful when only a single image need to
 be converted and pushed into a CernVM-FS repository.
 
 ::
@@ -190,16 +190,16 @@ be converted and pushed into a CernVM-FS repository.
 The command takes two arguments as input, the image to convert and the CernVM-FS
 repository where to store it.
 
-The `image-to-convert` argument follow the same syntax of the wishlist, for
-instance it could be something like `https://registry.hub.docker.com/library/fedora:latest`.
+The ``image-to-convert`` argument follow the same syntax of the wishlist, for
+instance it could be something like ``https://registry.hub.docker.com/library/fedora:latest``.
 
 
 Incremental Conversion
 ======================
 
-The `convert` command will extract image contents into CernVM-FS only where
+The ``convert`` command will extract image contents into CernVM-FS only where
 necessary. In general, some parts of the wish list will be already converted
-while others will need to be converted ex-novo.
+while others will need to be converted from scratch.
 
 An image that has been already unpacked in CernVM-FS will be skipped. For
 unconverted images, only the missing layers will be unpacked.
@@ -220,7 +220,7 @@ Notification
 ============
 
 DUCC provides a basic notification system to alert external services of
-updates in the filesystem.
+updates in the file system.
 
 The notifications are appended to a simple text file as JSON objects.
 
@@ -228,22 +228,22 @@ Human operator or software can follow the file and react on notification of
 interest.
 
 The notification file, eventually can grow large. The suggestion is to treat it
-as a standard log file with tools like `logrotate`.
+as a standard log file with tools like ``logrotate``.
 
 Multiple DUCC processes can write on the same notification file at the same
 time, multiple consumer can read from it.
 
 The notification are activated if and only if the user ask for them providing
 a file where to write them.
-To provide a notification file the flag `-n/--notification-file` is available.
+To provide a notification file the flag ``-n/--notification-file`` is available.
 
 Multiprocess
 ============
 
 DUCC is able to run multiprocess against the same CernVM-FS repository.
 
-Before to interact with the CernVM-FS repository, DUCC takes a filesystem
-level lock against `/tmp/DUCC.lock`.
+Before to interact with the CernVM-FS repository, DUCC takes a file system
+level lock against ``/tmp/DUCC.lock``.
 
 This allows to run multiple instances of DUCC at the same time, one instance
 could listen to a web socket, while one could be doing wishlist conversion.

--- a/cpt-enter.rst
+++ b/cpt-enter.rst
@@ -3,7 +3,8 @@
 Ephemeral Writable Container
 ============================
 
-**Note:** this feature is still considered experimental.
+.. note::
+    This feature is still considered experimental.
 
 The CernVM-FS ephemeral writable container can provide a short-lived shell with writable access to a regular, read-only CernVM-FS repository.
 A writable CernVM-FS mountpoint is normally a functionality that only publisher nodes provide.
@@ -41,5 +42,5 @@ If only the logs should be preserved, use the ``--keep-logs`` parameter instead.
 If necessary, the container can be opened as fake root user using the ``root`` option.
 
 Note that by default a dedicated CernVM-FS cache directory is created for the lifetime of the ephemeral container.
-It can be desireable to use a shared cache directory across several invocations of the ``cvmfs_server enter`` command.
+It can be desirable to use a shared cache directory across several invocations of the ``cvmfs_server enter`` command.
 To do so, use the ``--cvmfs-config <config file>`` parameter and set ``CVMFS_CACHE_BASE=/common/path`` in the passed configuration file.

--- a/cpt-graphdriver.rst
+++ b/cpt-graphdriver.rst
@@ -12,14 +12,14 @@ the CernVM-FS graph driver can remove the bottleneck of distributing (large)
 container images to (many) nodes.
 
 The CernVM-FS graph driver can run any normal image from a Docker registry.
-Additionally, it can run so called *Thin Images*. A thin image is like a
+Additionally, it can run so-called *Thin Images*. A thin image is like a
 symbolic link for container images. It is a regular, very small image in the
 registry. It contains a single file, the *thin image descriptor*, that specifies
 where in a CernVM-FS repository the actual image contents can be found. The
 ``docker2cvmfs`` utility can be used to convert a regular image to a thin image.
 
 .. figure:: _static/thin_image.svg
-   :alt: Comparision between regular container images and thin images
+   :alt: Comparison between regular container images and thin images
    :figwidth: 750
    :align: center
 
@@ -28,15 +28,15 @@ Requirements
 ------------
 
 The graph driver plugin requires Docker version > 17 and a host kernel with
-either aufs or overlay2 support, which includes RHEL >= 7.3. Please note that
+overlay2 support, which includes RHEL >= 7.3. Please note that
 on RHEL 7, Docker's data root should reside either on an ext file system or on
 an xfs file system that is formatted with the ``ftype=1`` mount option.
 
 The Docker graph driver plugin receives its CernVM-FS configuration by default
-from the Docker host's /etc/cvmfs directory. The easiest way to populate
-/etc/cvmfs is to install the ``cvmfs-config-default`` package (or any other
-``cvmfs-config-...`` package) on the Docker host.  Alternatively, a directory
-structure resembling the /etc/cvmfs hierarchy can by manually created and linked
+from the Docker host's ``/etc/cvmfs`` directory. The easiest way to populate
+``/etc/cvmfs`` is to install the ``cvmfs-config-default`` package (or any other
+``cvmfs-config-...`` package) on the Docker host. Alternatively, a directory
+structure resembling the ``/etc/cvmfs`` hierarchy can be manually created and linked
 to the graph driver plugin.
 
 
@@ -76,13 +76,13 @@ The following steps install and activate the CernVM-FS graph driver plugin.
         docker run -it --rm cvmfs/thin_ubuntu /bin/bash
 
 In order to get debugging output, add ``"debug": true`` to the
-/etc/docker/daemon.json file.
+``/etc/docker/daemon.json`` file.
 
 
 Location of the Plugin Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the plugin tries to bind mount the host's /etc/cvmfs directory
+By default, the plugin tries to bind mount the host's ``/etc/cvmfs`` directory
 as a source of configuration. Other locations can be linked to the container
 by running ::
 
@@ -95,14 +95,15 @@ Installation from a Plugin Tarball
 
 Instead of installing the plugin from the Docker registry, it can be installed
 directly from a tarball. To do so, `download <https://ecsft.cern.ch/dist/cvmfs/docker-graphdriver>`_
-and untar a graph driver plugin tarball.  Run ::
+and untar a graph driver plugin tarball. Run ::
 
     docker plugin create my-graphdriver cvmfs-graphdriver-plugin-$VERSION
     docker plugin enable my-graphdriver
 
-**Note**: currently, the graph driver name (``my-graphdriver``) must not contain
-a colon (``:``) nor a comma (``,``).  This issue will be fixed in a later
-version.
+.. Note::
+  Currently, the graph driver name (``my-graphdriver``) must not contain
+  a colon (``:``) nor a comma (``,``). This issue will be fixed in a later
+  version.
 
 
 Conversion of Images
@@ -114,10 +115,10 @@ through a small utility ``docker2cvmfs``.
 At the moment it is possible to directly download the executable:
 `docker2cvmfs v0.3 <https://ecsft.cern.ch/dist/cvmfs/docker2cvmfs/0.3/docker2cvmfs>`_
 
-``docker2cvmfs`` provides different commands to manipulate docker images but
-the simplest way is to use the ``make-thin`` sub-command.
+``docker2cvmfs`` provides different commands to manipulate docker images, though
+the simplest way is to use the ``make-thin`` subcommand.
 
-This sub-command expects to find on the host machine a recent version of
+This subcommand expects to find on the host machine a recent version of
 ``cvmfs_server`` that supports the ``ingest`` command.
 
 Invoking the help of the subcommand ``docker2cvmfs make-thin --help`` explains
@@ -138,7 +139,7 @@ the several layers (``example.cern.ch``).
 The utility downloads every layer that composes the image, stores them into the
 repository, creates the new thin image and imports that into docker.
 
-By default the layers are stored into the ``layers/`` subdirectory of the
+By default, the layers are stored into the ``layers/`` subdirectory of the
 repository; this can be modified using the ``--subdirectory`` parameters.
 
 The images are downloaded, by default, from the official docker hub registry,

--- a/cpt-hpc.rst
+++ b/cpt-hpc.rst
@@ -16,27 +16,27 @@ These problems can be overcome as described in the following sections.
 Running CernVM-FS as an unprivileged user
 -----------------------------------------
 CernVM-FS can be run as an unprivileged user under several different
-scenarios.  See documentation about that in the Security 
+scenarios. See documentation about that in the Security
 :ref:`sct_running_client_as_normal_user` section.
 
 
-Parrot-Mounted CernVM-FS in lieu of Fuse Module
+Parrot-Mounted CernVM-FS instead of Fuse Module
 -----------------------------------------------
-Instead of accessing /cvmfs through a Fuse module, processes can use the
+Instead of accessing ``/cvmfs`` through a Fuse module, processes can use the
 `Parrot connector <http://cernvm.cern.ch/portal/filesystem/parrot>`_. The parrot
 connector works on x86_64 Linux if the ``ptrace`` system call is not disabled.
 In contrast to a plain copy of a CernVM-FS repository to a shared file system,
 this approach has the following advantages:
 
-  * Millions of synchronized meta-data operations per node (path lookups, in
+  * Millions of synchronized metadata operations per node (path lookups, in
     particular) will not drown the shared cluster file system but resolve
     locally in the parrot-cvmfs clients.
   * The file system is always consistent; applications never see
     half-synchronized directories.
-  * After initial preloading, only change sets need to be transfered to the
-    shared file system.  This is much faster than `rsync`, which always has to
+  * After initial preloading, only change sets need to be transferred to the
+    shared file system. This is much faster than `rsync`, which always has to
     browse the entire name space.
-  * Identical files are internally de-duplicated.  While space of the order of
+  * Identical files are internally deduplicated. While space of the order of
     terabytes is usually not an issue for HPC shared file systems, file system
     caches benefit from deduplication. It is also possible to preload only
     specific parts of a repository namespace.
@@ -50,11 +50,10 @@ Downloading complete snapshots of CernVM-FS repositories
 When there is no possible way to run the CernVM-FS client, an option
 that has been used on some HPC systems is to download entire or
 partial snapshots of CernVM-FS repositories using the
-:ref:`cvmfs_shrinkwrap utility <cpt_shrinkwrap>`.  These snapshots
+:ref:`cvmfs_shrinkwrap utility <cpt_shrinkwrap>`. These snapshots
 are also sometimes called "HPC fat container images".
-This has many
-disadvantages compared to running a CernVM-FS client so it is typically
-a last resort.  
+This has many disadvantages compared to running a CernVM-FS client,
+so it is typically a last resort.
 
 
 NFS Export with Cray DVS
@@ -62,10 +61,14 @@ NFS Export with Cray DVS
 
 Some HPC sites have tried running the cvmfs client on just one server
 and exporting to worker nodes over :ref:`NFS <sct_nfs_server_mode>`.
-These installations can be made to work but it is very inefficient and
-they often run into operational problems.   If you want to try it using
+These installations can be made to work, but they are very inefficient,
+and often run into operational problems.
+If you want to try it out anyway using
 the Cray DVS please see the :ref:`workaround <sct_nfs_interleaved>` on
 inode handling and DVS export.
+
+.. note::
+  NFS export is not a recommended setup to run cvmfs.
 
 
 Preloading the CernVM-FS Cache
@@ -76,10 +79,10 @@ whatever reason on-demand downloading to a local cache is difficult, the
 `cvmfs_preload utility <http://cernvm.cern.ch/portal/filesystem/downloads>`_
 can be used to preload a CernVM-FS cache onto the shared cluster file system.
 Internally it uses the same code that is used to replicate between CernVM-FS
-stratum 0 and stratum 1.  The ``cvmfs_preload`` command is a self-extracting
+stratum 0 and stratum 1. The ``cvmfs_preload`` command is a self-extracting
 binary with no further dependencies and should work on a majority of x86_64
-Linux hosts.  Note however that this method can significantly strain the
-cluster file system's meta-data server(s) and that many HPC systems have
+Linux hosts. Note however that this method can significantly strain the
+cluster file system's metadata server(s) and that many HPC systems have
 had better results with
 :ref:`loopback filesystems <sct_loopback_filesystems>`
 as node caches as discussed below.
@@ -87,16 +90,16 @@ as node caches as discussed below.
 The ``cvmfs_preload`` command replicates from a stratum 0 (not from a
 stratum 1). Because this induces significant load on the source server,
 stratum 0 administrators should be informed before using their server as a
-source.  As an example, in order to preload the ALICE repository into
+source. As an example, in order to preload the ALICE repository into
 /shared/cache, one could run from a login node
 
 ::
 
     cvmfs_preload -u http://cvmfs-stratum-zero-hpc.cern.ch:8000/cvmfs/alice.cern.ch -r /shared/cache
 
-This will preload the entire repository.  In order to preload only specific
-parts of the namespace, you can create a _dirtab_ file with path prefixes.  The
-path prefixes must not involve symbolic links.  An example dirtab file for ALICE
+This will preload the entire repository. In order to preload only specific
+parts of the namespace, you can create a _dirtab_ file with path prefixes. The
+path prefixes must not involve symbolic links. An example dirtab file for ALICE
 could look like
 
 ::
@@ -108,16 +111,16 @@ could look like
     /example/x86_64-2.6-gnu-4.8.3/Packages/gcc
     /example/x86_64-2.6-gnu-4.8.3/Packages/AliRoot/v5*
 
-The corresponding invokation of ``cvmfs_preload`` is
+The corresponding invocation of ``cvmfs_preload`` is
 
 ::
 
     cvmfs_preload -u http://cvmfs-stratum-zero-hpc.cern.ch:8000/cvmfs/alice.cern.ch -r /shared/cache \
       -d </path/to/dirtab>
 
-The initial preloading can take several hours to a few days.  Subsequent
-invokations of the same command only transfer a change set and typically finish
-within seconds or minutes. These subsequent invokations need to be either done
+The initial preloading can take several hours to a few days. Subsequent
+invocations of the same command only transfer a change set and typically finish
+within seconds or minutes. These subsequent invocations need to be either done
 manually when necessary or scheduled for instance with a cron job.
 
 The ``cvmfs_preload`` command can preload files from multiple repositories
@@ -133,9 +136,9 @@ as an *Alien Cache*. Since there won't be cache misses, parrot or fuse clients
 do not need to download additional files from the network.
 
 If clients do have network access, they might find a repository version online
-that is newer than the preloaded version in the cache.  This results in
+that is newer than the preloaded version in the cache. This results in
 conflicts with ``cvmfs_preload`` or in errors if the cache directory is
-read-only.  Therefore, we recommend to explicitly disable network access for the
+read-only. Therefore, we recommend to explicitly disable network access for the
 parrot process on the nodes, for instance by setting
 
 ::
@@ -171,8 +174,8 @@ shared file system.
 
 Because there is only a single file for every node, the parallelism of
 the cluster file system can be exploited and all the requests from
-CernVM-FS circumvent the cluster file system's meta-data server(s).
-That can be a very large advantage because very often the meta-data
+CernVM-FS circumvent the cluster file system's metadata server(s).
+That can be a very large advantage because very often the metadata
 server is the bottleneck under typical workloads.
 
 

--- a/cpt-large-scale.rst
+++ b/cpt-large-scale.rst
@@ -4,9 +4,9 @@
 Large-Scale Data CernVM-FS
 ==========================
 
-CernVM-FS primarily is developed for distributing large software stacks.  However, by
+CernVM-FS primarily is developed for distributing large software stacks. However, by
 combining several extensions to the base software, one can use CVMFS to distribute
-large, non-public datasets.  While there are several ways to deploy a the service,
+large, non-public datasets. While there are several ways to deploy the service,
 in this section we outline one potential path to achieve secure distribution of
 terabytes-to-petabytes of data.
 
@@ -14,65 +14,65 @@ To deploy large-scale CVMFS, a few design decisions are needed:
 
 -  **How is data distributed?** For the majority of repositories, data is replicated from a
    repository server to an existing content distribution network tuned for the object size
-   common to software repositories.  The CDNs currently in use are tuned for working set
+   common to software repositories. The CDNs currently in use are tuned for working set
    size on the order of tens of gigabytes; they are not appropriately sized for terabytes
-   of data.  You will need to put together a mechanism for delivering data at the rates
+   of data. You will need to put together a mechanism for delivering data at the rates
    your clients will need.
 
-    -  For example, ``ligo.osgstorage.org`` has about 20TB of data; each scientific workflow
-       utilizes about 2TB of data and each running core averages 1Mbps of input data.  So,
-       to support the expected workflows at 10,000 running cores, several 10TB caches were
+    -  For example, ``ligo.osgstorage.org`` has about 20 TB of data; each scientific workflow
+       utilizes about 2 TB of data and each running core averages 1Mbps of input data. So,
+       to support the expected workflows at 10,000 running cores, several 10 TB caches were
        deployed that could export a total of 40Gbps.
-    -  The ``cms.osgstorage.org`` repository publishes 3PB of data.  Each analysis will
-       read around 20TB and several hundred analyses will run simultaneously.  Given the
+    -  The ``cms.osgstorage.org`` repository publishes 3 PB of data. Each analysis will
+       read around 20 TB and several hundred analyses will run simultaneously. Given the
        large working set size, there is no caching layer and data is read directly from
        large repositories.
 
 -  **How is data published?** By default, CVMFS publication will calculate checksums
-   on its contents, compresses the data, and serves it from the Apache web server.  Implicitly,
+   on its contents, compresses the data, and serves it from the Apache web server. Implicitly,
    this means all data must be _copied_ to and _stored_ on the repository host; at larger scales,
-   this is prohibitively expensive.  The ``cvmfs_swissknife graft`` tool provides a mechanism
+   this is prohibitively expensive. The ``cvmfs_swissknife graft`` tool provides a mechanism
    to publish files directly if the checksum is known ahead of time; see :ref:`sct_grafting`.
 
     -  For ``ligo.osgstorage.org``, a cronjob *copies* all new data to the repository from a cache,
-       creates the checksum file, and immediately deletes the downloaded file.  Hence, the LIGO
+       creates the checksum file, and immediately deletes the downloaded file. Hence, the LIGO
        data is copied but not stored.
-    -  The ``cms.osgstorage.org``, a cronjob queries the underlying filesystem for the relevant
-       checksum information and published the checksum.  The data is neither copied nor stored
+    -  The ``cms.osgstorage.org``, a cronjob queries the underlying file system for the relevant
+       checksum information and published the checksum. The data is neither copied nor stored
        on the repository
 
-   On publication, the files may be marked as *non-compressed* and *externally stored*.  This
+   On publication, the files may be marked as *non-compressed* and *externally stored*. This
    allows the CVMFS client to be configured to be pointed at a non-CVMFS data (stored as the "logical
-   name", not the "content addressed" form).  CVMFS clients can thus use existing data sources without
+   name", not the "content addressed" form). CVMFS clients can thus use existing data sources without
    change.
 -  **How is data secured?** CVMFS was originally designed to distribute open-source software
-   with strong data integrity guarantees.  More recently, read-access authorization has been added
-   to the software.  An access control list is added to the repository (at creation time or publication
-   time) and clients are configured to invoke a plugin for new process sessions.  The plugin enforces the ACLs
-   *and* forwards the user's credential back to the CVMFS process.  This allows the authorization to be
+   with strong data integrity guarantees. More recently, read-access authorization has been added
+   to the software. An access control list is added to the repository (at creation time or publication
+   time) and clients are configured to invoke a plugin for new process sessions. The plugin enforces the ACLs
+   *and* forwards the user's credential back to the CVMFS process. This allows the authorization to be
    enforced for worker node cache access and the CDN to enforce authorization on the CVMFS process for
    downloading new files to the cache.
 
    The entire ACL is passed to the external plugin and not interpreted by CVMFS; the semantics are defined
-   by the plugin.  The existing plugin is based on GSI / X509 proxies and authorization can be added based
+   by the plugin. The existing plugin is based on GSI / X509 proxies and authorization can be added based
    on DN or VOMS FQANs.
 
-   In order to perform mounts, the root catalog must be accessible without authorization.  However, the repository
+   In order to perform mounts, the root catalog must be accessible without authorization. However, the repository
    server (or CDN) can be configured to require authorization for the remaining data in the namespace.
 
 Creating Large, Secure Repositories
 -----------------------------------
 
-For large-scale repositories, a few tweaks are useful at creation time.  Here is the command used to
+For large-scale repositories, a few tweaks are useful at creation time. Here is the command used to
 create the ``cms.osgstorage.org``::
 
    cvmfs_server mkfs -V cms:/cms -X -Z none -o cmsuser cms.osgstorage.org
 
 -  The ``-V cms:/cms`` option indicates that only clients with an X509 proxy with a VOMS extension
-   from CMS are allowed to access the mounted proxy.  If multiple VOMS extensions are needed, it's
+   from CMS are allowed to access the mounted proxy. If multiple VOMS extensions are needed, it's
    easiest to add this at publication time.
 -  ``-X`` indicates that, by default, files published to this repository are served at an "external
-   URL".  The clients will attempt to access the file by *name*, not content hash, and look for
+   URL". The clients will attempt to access the file by *name*, not content hash, and look for
    the server as specified by the client's setting of ``CVMFS_EXTERNAL_URL``.
 -  ``-Z none`` indicates that, by default, files published to this repository will not be marked as
    compressed.

--- a/cpt-notification-system.rst
+++ b/cpt-notification-system.rst
@@ -58,7 +58,7 @@ The subscription command has two optional flags:
   will output the message but will not exit.
 * ``-m NUM`` specifies of minimum repository revision number to react to. For
   messages with a revision number smaller than or equal to ``NUM``, no output
-  is printed and the command will not exit (when the ``-c`` flag is not given).
+  is printed, and the command will not exit (when the ``-c`` flag is not given).
 
 CernVM-FS client configuration
 ------------------------------

--- a/cpt-overview.rst
+++ b/cpt-overview.rst
@@ -15,10 +15,10 @@ well as a server-side toolkit to create such distributable CernVM-FS
 repositories.
 
 .. figure:: _static/concept-generic.svg
-   :alt: General overview over CernVM-File System's Architecture
+   :alt: General overview over CernVM File System's Architecture
 
    A CernVM-FS client provides a virtual file system that loads data
-   only on access. In this example, all releases of a sofware package
+   only on access. In this example, all releases of a software package
    (such as an HEP experiment framework) are hosted as a
    CernVM-FS repository on a web server.
 
@@ -30,13 +30,13 @@ Fuse [Suzaki06]_ and content-delivery networks [Freedman03]_
 [Nygren10]_ [Tolia03]_. Its current implementation provides the
 following key features:
 
--  Use of the the `Fuse kernel module <http://fuse.sourceforge.net>`_
+-  Use of the `Fuse kernel module <http://fuse.sourceforge.net>`_
    that comes with in-kernel caching of file attributes
 
 -  Cache quota management
 
 -  Use of a content addressable storage format resulting in immutable
-   files and automatic file de-duplication
+   files and automatic file deduplication
 
 -  Possibility to split a directory hierarchy into sub catalogs at
    user-defined levels
@@ -65,7 +65,7 @@ following key features:
 
 -  Automatic load-balancing of proxy servers
 
--  Support for WPAD/PAC auto-configuration of proxy servers
+-  Support for WPAD/PAC autoconfiguration of proxy servers
 
 -  Efficient replication of repositories
 
@@ -77,7 +77,7 @@ CernVM-FS is particularly crafted for fast and scalable software
 distribution. Running and compiling software is a use case general
 purpose distributed file systems are not optimized for. In contrast to
 virtual machine images or Docker images, software installed in
-CernVM-FS does not need to be further packaged. Instead it is
+CernVM-FS does not need to be further packaged. Instead, it is
 distributed and versioned file-by-file. In order to create and update a
 CernVM-FS repository, a distinguished machine, the so-called *Release
 Manager Machine*, is used. On such a release manager machine, a

--- a/cpt-plugins.rst
+++ b/cpt-plugins.rst
@@ -5,7 +5,7 @@ Client Plug-Ins
 
 The CernVM-FS client's functionality can be extended through plug-ins.
 CernVM-FS plug-ins are binaries (processes) that communicate with the main
-client process through IPC.  Currently there are two plug-in interfaces:
+client process through IPC. Currently, there are two plug-in interfaces:
 cache manager plugins and authorization helpers.
 
 .. _sct_plugin_cache:
@@ -15,14 +15,15 @@ Cache Plugins
 
 A cache plugin provides the functionality of the client's local cache directory:
 it maintains a set of content-addressed objects. Clients can read from these
-objects.  Depending on its capabilities, a cache plugin might also support
+objects. Depending on its capabilities, a cache plugin might also support
 addition of new objects, listing objects and eviction of objects from the cache.
 
-**Note:** The CernVM-FS client trusts the contents of the cache. Cache plugins
-that store data in untrusted locations need to perform their own content
-verification before data is provided to the clients.
+.. note::
+  The CernVM-FS client trusts the contents of the cache. Cache plugins
+  that store data in untrusted locations need to perform their own content
+  verification before data is provided to the clients.
 
-Cache plugins and clients exchange messages through a socket.  The messages are
+Cache plugins and clients exchange messages through a socket. The messages are
 serialized by the Google protobuf library. A description of the wire protocol
 can be found in the ``cvmfs/cache.proto`` source file, although the cache
 plugins should not directly implement the protocol. Instead, plugins are
@@ -73,8 +74,8 @@ Broadly speaking, a cache plugin process performs the following steps
     cvmcache_cleanup_global();
 
 The core of the cache plugin is the implementation of the callback functions
-provided to ``cvmcache_init()``.  Not all callback functions need to be
-implemented.  Some can be set to ``NULL``, which needs to correspond to the
+provided to ``cvmcache_init()``. Not all callback functions need to be
+implemented. Some can be set to ``NULL``, which needs to correspond to the
 indicated plugin capabilities specified in the ``capabilities`` bit vector.
 
 
@@ -83,15 +84,15 @@ Basic Capabilities
 
 Objects maintained by the cache plugin are identified by their content hash.
 Every cache plugin must be able to check whether a certain object is available
-or not and, if it is available, provide data from the object.  This
+or not and, if it is available, provide data from the object. This
 functionality is provided by the ``cvmcache_chrefcnt()``,
-``cvmcache_obj_info()``, and ``cvmcache_pread()`` callbacks.  With only this
+``cvmcache_obj_info()``, and ``cvmcache_pread()`` callbacks. With only this
 functionality, the cache plugin can be used as a read-only lower layer in a
 tiered cache but not as a stand-alone cache manager.
 
 For a proper stand-alone cache manager, the plugin must keep reference counting
-for its objects.  The concept of reference counting is borrowed from link counts
-in UNIX file systems.  Every object in a cache plugin has a reference counter
+for its objects. The concept of reference counting is borrowed from link counts
+in UNIX file systems. Every object in a cache plugin has a reference counter
 that indicates how many times the object is being in use by CernVM-FS clients.
 For objects in use, clients expect that reading succeeds, i.e. objects in use
 must not be deleted.
@@ -104,11 +105,11 @@ On a cache miss, clients need to populate the cache with the missing object.
 To do so, cache plugins provide a transactional write interface. The upload
 of an object results in the following call chain:
 
-  1. A call to ``cvmcache_start_txn()`` with a given transaction id
+  1. A call to ``cvmcache_start_txn()`` with a given transaction ID
 
   2. Zero, one, or multiple calls to ``cvmcache_write_txn()`` that append data
 
-  3. A call to ``cvmcache_commit_txn()`` ro ``cvmcache_abort_txn()``
+  3. A call to ``cvmcache_commit_txn()`` or ``cvmcache_abort_txn()``
 
 Only after commit the object must be accessible for reading. Multiple concurrent
 transactions on the same object are possible. After commit, the reference
@@ -122,7 +123,7 @@ Listing and Cache Space Management
 Listing of the objects in the cache and the ability to evict objects from the
 cache are optional capabilities. Only objects whose reference counter is zero
 may be evicted. Clients can keep file catalogs open for a long time, thereby
-preventing them from being evicted.  To mitigate that fact, cache plugins can
+preventing them from being evicted. To mitigate that fact, cache plugins can
 at any time send a notification to clients using ``cvmcache_ask_detach()``,
 asking them to close as many nested catalogs as they can.
 
@@ -134,38 +135,38 @@ Authorization Helpers
 ---------------------
 
 Client authorization helpers (*authz helper*) can be used to grant or deny read
-access to a mounted repository.  To do so, authorization helpers can verify the
-local UNIX user (uid/gid) and the process id (pid) that is issuing a file system
+access to a mounted repository. To do so, authorization helpers can verify the
+local UNIX user (uid/gid) and the process ID (pid) that is issuing a file system
 request.
 
 An authz helper is spawned by CernVM-FS if the root file catalog contains
-*membership requirement* (see below).  The binary to be spawned is derived from
-the membership requirement but it can be overwritten with the
-``CVMFS_AUTHZ_HELPER`` parameter.  The authz helper listens for commands on
-``stdin`` and it replies on ``stdout``.
+*membership requirement* (see below). The binary to be spawned is derived from
+the membership requirement, but it can be overwritten with the
+``CVMFS_AUTHZ_HELPER`` parameter. The authz helper listens for commands on
+``stdin``, and it replies on ``stdout``.
 
-Grant/deny decisions are typically cached for a while by the client.  Note that
-replies are cached for the entire session (session id) that contains the calling
-process id.
+Grant/deny decisions are typically cached for a while by the client. Note that
+replies are cached for the entire session (session ID) that contains the calling
+process ID.
 
 
 Membership Requirement
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The root file catalog of a repository determines if and which authz helper
-should be used by a client.  The membership requirement (also called
+should be used by a client. The membership requirement (also called
 *VOMS authorization*) can be set, unset, and changed when creating a
-repository and on every publish operation.  It has the form
+repository and on every publish operation. It has the form
 
 ::
 
       <helper>%<membership string>
 
-The ``<helper>`` component helps the client find an authz helper.  The client
-searches for a binary ``${CVMFS_AUTHZ_SEARCH_PATH}/cvmfs_<helper>_helper``.  By
-default, the search path is ``/usr/libexec/cvmfs/authz``.  CernVM-FS comes with
-two helpers: ``cvmfs_helper_allow`` and ``cvmfs_helper_deny``.  Both helpers
-make static decisions and disregard the membership string.  Other helpers can
+The ``<helper>`` component helps the client find an authz helper. The client
+searches for a binary ``${CVMFS_AUTHZ_SEARCH_PATH}/cvmfs_<helper>_helper``. By
+default, the search path is ``/usr/libexec/cvmfs/authz``. CernVM-FS comes with
+two helpers: ``cvmfs_helper_allow`` and ``cvmfs_helper_deny``. Both helpers
+make static decisions and disregard the membership string. Other helpers can
 use the membership string to specify user groups that are allowed to access a
 repository.
 
@@ -174,24 +175,24 @@ Authz Helper Protocol
 ~~~~~~~~~~~~~~~~~~~~~
 
 The authz helper gets spawned by the CernVM-FS client with ``stdin`` and
-``stdout`` connected. There is a command/reply style of messages.  Messages have
+``stdout`` connected. There is a command/reply style of messages. Messages have
 a 4 byte version (=1), a 4 byte length, and then a JSON text that needs to
 contain the top-level struct ``cvmfs_authz_v1 { ... }``. Communication starts
 with a handshake where the client passes logging parameters to the authz helper.
 The client then sends zero or more authorization requests, each of which is
-answered by a positive or negative permit.  A positive permit can include an
+answered by a positive or negative permit. A positive permit can include an
 access token that should be used to download data. The permits are cached by the
-client with a TTL that the helper can chose. On unmount, the client sends a quit
-command to the helper.
+client with a TTL chosen by the authz helper. On unmount, the client sends a quit
+command to the authz helper.
 
 When spawned, the authz helper's environment is prepopulated with all
 ``CVMFS_AUTHZ_...`` environment variables that are in the CernVM-FS client's
-environment.  Furthermore the parameter ``CVMFS_AUTHZ_HELPER=yes`` is set.
+environment. Furthermore, the parameter ``CVMFS_AUTHZ_HELPER=yes`` is set.
 
 The JSON snippet of every message contains ``msgid`` and ``revision`` integer
-fields.  The revision is currently 0 and unused.  Message ids indicate certain
-other fields that can or should be present.  Additional JSON text is ignored.
-The message id can be one of the following
+fields. The revision is currently 0 and unused. Message IDs indicate certain
+other fields that can or should be present. Additional JSON text is ignored.
+The message ID can be one of the following
 
 ======== =======================================================
 **Code** **Meaning**
@@ -206,23 +207,23 @@ The message id can be one of the following
 Handshake and Termination
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the JSON snippet of the hand shake, the CernVM-FS client transmits the fully
+In the JSON snippet of the handshake, the CernVM-FS client transmits the fully
 qualified repository name (``fqrn`` string field) and the syslog facility and
 syslog level the helper is supposed to use (``syslog_facility``,
-``syslog_level`` integer fields).  The handshake reply as well as the
+``syslog_level`` integer fields). The handshake reply as well as the
 termination have no additional payload.
 
 Verification Requests
 ^^^^^^^^^^^^^^^^^^^^^
 
 A verification request contains the uid, gid, and pid of the calling process
-(``uid``, ``gid``, ``pid`` integer fields).  It furthermore contains the
+(``uid``, ``gid``, ``pid`` integer fields). It furthermore contains the
 Base64 encoded membership string from the membership requirement
 (``membership`` string field).
 
 The permit has to contain a status indicating success or failure (``status``
 integer field) and a time to live for this reply in seconds (``ttl`` integer
-field).  The status can be one of the following
+field). The status can be one of the following
 
 ======== ========================================================
 **Code** **Meaning**
@@ -233,7 +234,7 @@ field).  The status can be one of the following
 3        User is not member of the required groups (deny access)
 ======== ========================================================
 
-On success, the permit can optionally conatain a Base64 encoded version of
+On success, the permit can optionally contain a Base64 encoded version of
 either an X.509 proxy certificate (``x509_proxy`` string field) or a bearer
 token (``bearer_token`` string field). These credentials are used by the
 CernVM-FS client when downloading nested catalogs files as client-side HTTPS

--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -8,18 +8,18 @@ There is experimental support for Power and RISC-V architectures.
 
 Overview
 --------
-The CernVM-FS repositories are located under /cvmfs.
+The CernVM-FS repositories are located under ``/cvmfs``.
 Each repository is identified by a *fully qualified repository name*.
-On Linux, mounting and un-mounting of the CernVM-FS is usually controlled by autofs and automount.
-That means that starting from the base directory /cvmfs different repositories are mounted automatically just by accessing them.
+On Linux, mounting and unmounting of the CernVM-FS is usually controlled by ``autofs`` and automount.
+That means that starting from the base directory ``/cvmfs`` different repositories are mounted automatically just by accessing them.
 A repository will be automatically unmounted after some automount-defined idle time.
-On macOS, mounting and un-mounting of the CernVM-FS is done by the user with ``sudo mount -t cvmfs /cvmfs/...`` commands.
+On macOS, mounting and unmounting of the CernVM-FS is done by the user with ``sudo mount -t cvmfs /cvmfs/...`` commands.
 
 
 Getting the Software
 --------------------
 The CernVM-FS source code and binary packages are available from the `CernVM website <https://cernvm.cern.ch/portal/filesystem/downloads>`_.
-However it is recommended to use the available package repositories that are also provided for the supported operating systems.
+However, it is recommended to use the available package repositories that are also provided for the supported operating systems.
 
 Scientific Linux/CentOS
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -54,7 +54,7 @@ To install the CVMFS package run
 Docker Container
 ~~~~~~~~~~~~~~~~
 
-The CernVM-FS service container can expose the /cvmfs directory tree to the host.
+The CernVM-FS service container can expose the ``/cvmfs`` directory tree to the host.
 Import the container with
 
 ::
@@ -79,8 +79,10 @@ Run the container as a system service with
       --volume /cvmfs:/cvmfs:shared \
       cvmfs/service:2.8.0-1
 
-Use ``docker stop`` to unmount the /cvmfs tree.
-Note that if you run multiple nodes (a cluster), you should use ``-e CVMFS_HTTP_PROXY`` to set a proper site proxy as described further down.
+Use ``docker stop`` to unmount the ``/cvmfs`` tree.
+
+.. note::
+    If you run multiple nodes (a cluster), use ``-e CVMFS_HTTP_PROXY`` to set a proper site proxy as described further down.
 
 Mac OS X
 ~~~~~~~~
@@ -107,7 +109,7 @@ Future releases will provide a signed and notarized package.
 Windows / WSL2
 ~~~~~~~~~~~~~~
 
-Follow the `Windows instructions <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ to install the Windows Subsytem for Linux (WSL2).
+Follow the `Windows instructions <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ to install the Windows Subsystem for Linux (WSL2).
 Install any of the Linux distributions and follow the instructions for the distribution in this guide.
 Whenever you open the Linux distribution, run
 
@@ -125,9 +127,9 @@ Configure AutoFS
 ~~~~~~~~~~~~~~~~
 
 For the basic setup, run ``cvmfs_config setup``.
-This ensures that the file /etc/auto.master.d/cvmfs.autofs exists containing ``/cvmfs /etc/auto.cvmfs`` and that the autofs service is running. Reload the autofs service in order to apply an updated configuration.
+This ensures that the file ``/etc/auto.master.d/cvmfs.autofs`` exists containing ``/cvmfs /etc/auto.cvmfs`` and that the ``autofs`` service is running. Reload the ``autofs`` service in order to apply an updated configuration.
 
-NB: For OpenSUSE uncomment the line ``#+dir:/etc/auto.master.d/`` in the file /etc/auto.master and restart the autofs service.
+NB: For OpenSUSE uncomment the line ``#+dir:/etc/auto.master.d/`` in the file ``/etc/auto.master`` and restart the ``autofs`` service.
 
 ::
 
@@ -138,7 +140,7 @@ NB: For OpenSUSE uncomment the line ``#+dir:/etc/auto.master.d/`` in the file /e
 Mac OS X
 ~~~~~~~~
 
-Due to the lack of autofs on macOS, mount the individual repositories manually like
+Due to the lack of ``autofs`` on macOS, mount the individual repositories manually like
 
 ::
 
@@ -164,14 +166,14 @@ For an individual workstation or laptop, set
 
     CVMFS_CLIENT_PROFILE=single
 
-If you setup a cluster of cvmfs nodes, specify the HTTP proxy servers on your site with
+If you set up a cluster of cvmfs nodes, specify the HTTP proxy servers on your site with
 
 ::
 
     CVMFS_HTTP_PROXY="http://myproxy1:port|http://myproxy2:port"
 
 If you're unsure about the proxy names, set ``CVMFS_HTTP_PROXY=DIRECT``.
-This should *only* be done for a small number of clients (< 5), because large numbers can put a heavy load on the Stratum 1 servers and result, amongst others, in poorer performance for the client.
+This should *only* be done for very few clients (< 5), because large numbers can put a heavy load on the Stratum 1 servers and result, amongst others, in poorer performance for the clients.
 For the syntax of more complex HTTP proxy settings, see :ref:`sct_network`.
 If there are no HTTP proxies yet at your site, see :ref:`cpt_squid` for instructions on how to set them up.
 
@@ -179,7 +181,7 @@ Verify the file system
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Check if CernVM-FS mounts the specified repositories by ``cvmfs_config probe``.
-If the probe fails, try to restart autofs with ``sudo systemctl restart autofs``.
+If the probe fails, try to restart ``autofs`` with ``sudo systemctl restart autofs``.
 
 Building from source
 --------------------
@@ -205,7 +207,7 @@ For example, in case of Fuse3 following variables must be set: ``FUSE3_INCLUDE_D
 
 Furthermore, ``CMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON`` must be set, otherwise will ``sudo make install`` strip all linked libraries that point to none-system libraries.
 
-Example code for building CernVM-FS with locally built Fuse3 and including the CernVM-FS unittests and gateway:
+Example code for building CernVM-FS with locally built Fuse3 and including the CernVM-FS unit tests and gateway:
 ::
 
     cmake -DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON \
@@ -226,7 +228,7 @@ Troubleshooting
 
     cvmfs_config chksetup
 
-- CernVM-FS gathers its configuration parameter from various configuration files that can overwrite each others settings (default configuration, domain specific configuration, local setup, ...). To show the effective configuration for *repository*.cern.ch, run
+- CernVM-FS gathers its configuration parameter from various configuration files that can overwrite each other's settings (default configuration, domain specific configuration, local setup, ...). To show the effective configuration for *repository*.cern.ch, run
 
 ::
 
@@ -245,7 +247,7 @@ Troubleshooting
 
     /usr/sbin/setenforce 0
 
-- Once the issue has been identified, ensure that the changes are taken by restarting autofs
+- Once the issue has been identified, ensure that the changes are taken by restarting ``autofs``
 
 ::
 
@@ -259,4 +261,4 @@ Troubleshooting
 
     cvmfs_config wipecache
 
-- Finally running with debug logs enabled can provide additional information for bug reports. This can be done by specifying a log file path in the client settings, e.g: ``CVMFS_DEBUGLOG=/tmp/cvmfs.log``. See  :ref:`sct_debug_logs` for more details.
+- Finally running with debug logs enabled can provide additional information for bug reports. This can be done by specifying a log file path in the client settings, e.g: ``CVMFS_DEBUGLOG=/tmp/cvmfs.log``. See :ref:`sct_debug_logs` for more details.

--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -4,7 +4,7 @@ Setting up a Replica Server (Stratum 1)
 =======================================
 
 While a CernVM-FS Stratum 0 repository server is able to serve clients
-directly, a large number of clients is better be served by a set of Stratum 1
+directly, when having many clients it is better to serve them by a set of Stratum 1
 replica servers. Multiple Stratum 1 servers improve the reliability, reduce
 the load, and protect the Stratum 0 master copy of the repository from direct
 accesses. Stratum 0 server, Stratum 1 servers and the site-local proxy servers
@@ -49,20 +49,20 @@ Recommended Setup
 
 The vast majority of HTTP requests will be served by the site's local
 proxy servers. Being a publicly available service, however, we recommend
-to install a Squid frontend in front of the Stratum 1 web server.
+installing a Squid frontend in front of the Stratum 1 web server.
 
 We suggest the following key parameters:
 
 **Storage**
     RAID-protected storage. The ``cvmfs_server`` utility should have low
-    latency to the storage because it runs a large number of system
-    calls (``stat()``) against it. For the local storage backends ext3/4
-    filesystems are preferred (rather than XFS).
+    latency to the storage because it runs lots of system calls (``stat()``)
+    against it. For the local storage backends ext3/4 file systems are
+    preferred (rather than XFS).
 
 **Web server**
     A standard Apache server. Directory listing is not required. In
     addition, it is a good practice to exclude search engines from the
-    replica web server by an appropriate robots.txt. The webserver
+    replica web server by an appropriate robots.txt. The web server
     should be close to the storage in terms of latency.
 
 **Squid frontend**
@@ -74,21 +74,21 @@ We suggest the following key parameters:
     helpful for the responses to geo api calls. Using a squid is also
     helpful for participating in shared monitoring such as the `WLCG
     Squid Monitor <http://wlcg-squid-monitor.cern.ch>`_.
-    
+
     Alternatively, separate Squid server machines may be configured in a
     round-robin DNS and each forward to the Apache server, but note that
     if any of them are down the entire service will be considered down
-    by CernVM-FS clients.  A front end hardware load balancer that
+    by CernVM-FS clients. A front end hardware load balancer that
     quickly takes a machine that is down out of service would help
     reduce the impact.
 
 **High availability**
     On the subject of availability, note that it is not advised to use
     two separate complete Stratum 1 servers in a single round-robin
-    service because they will be updated at different rates.  That would
+    service because they will be updated at different rates. That would
     cause errors when a client sees an updated catalog from one Stratum
     1 but tries to read corresponding data files from the other that does
-    not yet have the files.  Different Stratum 1s should either be
+    not yet have the files. Different Stratum 1s should either be
     separately configured on the clients, or a pair can be configured as
     a high availability active/standby pair using the cvmfs-contrib
     `cvmfs-hastratum1 package <https://github.com/cvmfs-contrib/cvmfs-hastratum1>`_.
@@ -96,11 +96,11 @@ We suggest the following key parameters:
     between two different servers.
 
 **DNS cache**
-    The geo api on a Stratum 1 does DNS lookups.  It caches lookups
+    The geo api on a Stratum 1 does DNS lookups. It caches lookups
     for 5 minutes so the DNS server load does not tend to be severe, but
     we still recommend installing a DNS caching mechanism on the machine
-    such as ``dnsmasq`` or ``bind``.  We do not recommend ``nscd`` since
-    it does not honor the DNS Time-To-Live protocol.  
+    such as ``dnsmasq`` or ``bind``. We do not recommend ``nscd`` since
+    it does not honor the DNS Time-To-Live protocol.
 
 Apache Configuration
 --------------------
@@ -113,7 +113,7 @@ Multi-Process Module (MPM) and instead use the "worker" or "event"
 MPM which perform much better under heavy load because they work
 with multiple threads per process.
 That can be done by changing which module is uncommented in
-``/etc/httpd/conf.modules.d/00-mpm.conf``.  
+``/etc/httpd/conf.modules.d/00-mpm.conf``.
 The "event" MPM is the default on Red Hat Enterprise Linux 8.
 
 Squid Configuration
@@ -121,11 +121,11 @@ Squid Configuration
 
 If you participate in the Open Science Grid (OSG) or the European Grid
 Infrastructure (EGI), you are encouraged to use their distribution of
-squid called frontier-squid.  It is kept up to date with the latest
+squid called frontier-squid. It is kept up to date with the latest
 squid bug fixes and has features for easier upgrading and monitoring.
 Step-by-step instructions for setting it up with a Stratum 1 is
 available in the `OSG documentation
-https://opensciencegrid.org/docs/other/install-cvmfs-stratum1/#configuring-frontier-squid`_.
+<https://opensciencegrid.org/docs/other/install-cvmfs-stratum1/#configuring-frontier-squid>`_.
 
 Otherwise, a `squid` package is available in most Linux operating systems.
 The Squid configuration differs from the site-local Squids because the
@@ -172,22 +172,23 @@ prior to starting the squid service.
 
 The Squid also needs to respond to port 80, but Squid might not have the
 ability to directly listen there if it is run unprivileged, plus Apache
-listens on port 80 by default.  Direct external port 80 traffic to port
+listens on port 80 by default. Direct external port 80 traffic to port
 8000 with the following command:
 
 ::
 
     iptables -t nat -A PREROUTING -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8000
 
-If IPv6 is supported, do the same command with ``ip6tables``.  This will
+If IPv6 is supported, do the same command with ``ip6tables``. This will
 leave localhost traffic to port 80 going directly to Apache, which is
-good because ``cvmfs_server`` uses that and it doesn't need to go
+good because ``cvmfs_server`` uses that, and it doesn't need to go
 through squid.
 
-**Note**: Port 8000 might be assigned to ``soundd``.  On SElinux systems,
-this assignment must be changed to the HTTP service by
-``semanage port -m -t http_port_t -p tcp 8000``.  The ``cvmfs-server``
-RPM for EL7 executes this command as a post-installation script.
+.. note::
+    Port 8000 might be assigned to ``soundd``. On SElinux systems,
+    this assignment must be changed to the HTTP service by
+    ``semanage port -m -t http_port_t -p tcp 8000``. The ``cvmfs-server``
+    RPM for EL7 executes this command as a post-installation script.
 
 .. _sct_geoip_db:
 
@@ -195,9 +196,9 @@ Geo API Setup
 -------------
 
 One of the essential services supplied by Stratum 1s to CernVM-FS
-clients is the Geo API.  This enables clients to share configurations
+clients is the Geo API. This enables clients to share configurations
 worldwide while automatically sorting Stratum 1s geographically to
-prioritize connecting to the closest ones.  This makes use of a GeoIP
+prioritize connecting to the closest ones. This makes use of a GeoIP
 database from `Maxmind <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_
 that translates IP addresses of clients to longitude and latitude.
 
@@ -206,8 +207,8 @@ The database is free, but the Maxmind
 requires that each user of the database
 `sign up for an account <https://www.maxmind.com/en/geolite2/signup/>`_
 and promise to update the database to the latest version within 30 days
-of when they issue a new version.  The signup process will end with
-giving you a License Key.  The ``cvmfs_server`` ``add-replica`` and
+of when they issue a new version. The signup process will end with
+giving you a License Key. The ``cvmfs_server`` ``add-replica`` and
 ``snapshot`` commands will take care of automatically updating the
 database if you put a line like the following in
 ``/etc/cvmfs/server.local``, replacing ``<license key>`` with the key
@@ -222,25 +223,25 @@ You can test that it works by running ``cvmfs_server update-geodb``.
 
 Alternatively, if you have a separate mechanism of installing and
 updating the Geolite2 City database file, you can instead set
-``CVMFS_GEO_DB_FILE`` to the full path where you have installed it.  If
+``CVMFS_GEO_DB_FILE`` to the full path where you have installed it. If
 the path is ``NONE``, then no database will be required, but note that
 this will break the client Geo API so only use it for testing, when the
-server is not used by production clients.  If the database is installed
+server is not used by production clients. If the database is installed
 in the default directory used by Maxmind's own
 `geoipupdate <https://dev.maxmind.com/geoip/geoipupdate/>`_ tool,
 ``/usr/share/GeoIP``, then ``cvmfs_server`` will use it from there and
 neither variable needs to be set.
 
 Normally repositories on Stratum 1s are created owned by root, and the
-``cvmfs_server snapshot`` command is run by root.  If you want to use a
-different user id while still using the builtin mechanism for updating
+``cvmfs_server snapshot`` command is run by root. If you want to use a
+different user ID while still using the built-in mechanism for updating
 the geo database, change the owner of ``/var/lib/cvmfs-server/geo`` and
-``/etc/cvmfs/server.local`` to the user id.
+``/etc/cvmfs/server.local`` to the user ID.
 
-The builtin geo database update mechanism normally checks for updates
+The built-in geo database update mechanism normally checks for updates
 once a week on Tuesdays but can be controlled through a set of variables
-defined in ``cvmfs_server`` beginning with ``CVMFS_UPDATEGEO_``.  Look
-in the ``cvmfs_server`` script for the details.  An update can also be
+defined in ``cvmfs_server`` beginning with ``CVMFS_UPDATEGEO_``. Look
+in the ``cvmfs_server`` script for the details. An update can also be
 forced at any time by running ``cvmfs_server update-geodb``.
 
 Monitoring
@@ -249,7 +250,7 @@ Monitoring
 The ``cvmfs_server`` utility reports status and problems to ``stdout``
 and ``stderr``.
 
-For the web server infrastructure, we recommend 
+For the web server infrastructure, we recommend
 `cvmfs-servermon <https://github.com/cvmfs-contrib/cvmfs-servermon>`_
 which watches for problems in every repository's ``.cvmfs_status.json``
 status file.
@@ -268,16 +269,16 @@ Maintenance processes
 
 If any replicated repositories have Garbage Collection enabled, the
 Stratum 1 also needs to run garbage collection in order to prevent the
-disk space usage from growing rapidly.  Run ``cvmfs_server gc -af``
-periodically (e.g daily or weekly) from cron to run garbage collection
-on all repositories that have garbage collection enabled.  Logs will
-go into /var/log/cvmfs/gc.log. 
+disk space usage from growing rapidly. Run ``cvmfs_server gc -af``
+periodically (e.g. daily or weekly) from cron to run garbage collection
+on all repositories that have garbage collection enabled. Logs will
+go into ``/var/log/cvmfs/gc.log``.
 
 In addition, over time problems can show up with a small percentage of
-files stored on a large Stratum 1.  Run ``cvmfs_server check -a`` daily
-from cron to start a check process.  On a large Stratum 1 it will run
-for many days, but only with a single thread so it is not very
-intrusive.  If another check is still in process a new one will not
-start.  Each repository by default will only be checked at most once
-every 30 days.  Logs will go into /var/log/cvmfs/checks.log and 
+files stored on a large Stratum 1. Run ``cvmfs_server check -a`` daily
+from cron to start a check process. On a large Stratum 1 it will run
+for many days, but only with a single thread, so it is not very
+intrusive. If another check is still in process a new one will not
+start. Each repository by default will only be checked at most once
+every 30 days. Logs will go into ``/var/log/cvmfs/checks.log`` and
 problems will be recorded in a repository's ``.cvmfs_status.json``.

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -12,9 +12,9 @@ All data stored in CernVM-FS have to be converted into a
 CernVM-FS *repository* during the process of publishing. The
 CernVM-FS repository is a form of content-addressable storage.
 Conversion includes creating the file catalog(s), compressing new and
-updated files and calculating content hashes. Storing the data in a
+updated files, and calculating content hashes. Storing the data in a
 content-addressable format results in automatic file de-duplication. It
-furthermore simplifies data verification and it allows for file system
+furthermore simplifies data verification, and it allows for file system
 snapshots.
 
 In order to provide a writable CernVM-FS repository, CernVM-FS uses a union
@@ -32,30 +32,23 @@ System Requirements
 
 -  union file system in the kernel
 
-   - AUFS
-
    - OverlayFS (as of kernel version 4.2.x or RHEL7.3)
 
 -  Officially supported platforms
 
-   -  CentOS/SL >= 7.3, provided that /var/spool/cvmfs is served by an ext4
+   -  CentOS/SL >= 7.3, provided that ``/var/spool/cvmfs`` is served by an ext4
       file system.
 
    -  Fedora 25 and above (with kernel :math:`\ge` 4.2.x)
 
-   -  Ubuntu 14.04 64 bit and above
-
-       - Ubuntu < 15.10: with installed AUFS kernel module
-         (cf. `linux-image-extra` package)
-
-       - Ubuntu 15.10 and later (using upstream OverlayFS)
+   -  Ubuntu 15.10 and above (using upstream OverlayFS)
 
 Installation
 ~~~~~~~~~~~~
 
 #. Install ``cvmfs`` and ``cvmfs-server`` packages
 
-#. Ensure enough disk space in ``/var/spool/cvmfs`` (>50GiB)
+#. Ensure enough disk space in ``/var/spool/cvmfs`` (>50 GiB)
 
 #. For local storage: Ensure enough disk space in ``/srv/cvmfs``
 
@@ -86,7 +79,7 @@ Backup Policy
 
    -  For local storage: ``/srv/cvmfs``
 
-   -  Stratum 1s can serve as last-ressort backup of repository content
+   -  Stratum 1s can serve as last resort backup of repository content
 
 .. _sct_publish_revision:
 
@@ -120,8 +113,8 @@ editing of files where changes are stored on a RAM disk.
 
 If a file in the CernVM-FS repository gets changed, the union file system
 first copies it to the writable volume and applies any changes to this copy
-(copy-on-write semantics). Also newly created files or directories will be
-stored in the writable volume. Additionally the union file system creates
+(copy-on-write semantics). Also, newly created files or directories will be
+stored in the writable volume. Additionally, the union file system creates
 special hidden files (called *white-outs*) to keep track of file
 deletions in the CernVM-FS repository.
 
@@ -138,15 +131,16 @@ Requirements for a new Repository
 ---------------------------------
 
 In order to create a repository, the server and client part of
-CernVM-FS must be installed on the release manager machine. Furthermore
+CernVM-FS must be installed on the release manager machine. Furthermore,
 you will need a kernel containing a union file system implementation as
-well as a running ``Apache2`` web server. Currently we support EL >= 7.3,
+well as a running ``Apache2`` web server. Currently, we support EL >= 7.3,
 Ubuntu 14.04+ and Fedora 25+ distributions.
 
-CernVM-FS supports both OverlayFS and aufs as a union file system.
+CernVM-FS supports OverlayFS as a union file system.
+Earlier versions also supported ``aufs``, but no active support is given anymore.
 At least a 4.2.x kernel is needed to use CernVM-FS with OverlayFS. (Red Hat)
-Enterprise Linux >= 7.3 works, too, provided that /var/spool/cvmfs is served by
-an ext3 or ext4 file system. Furthermore note that OverlayFS cannot fully comply
+Enterprise Linux >= 7.3 works, too, provided that ``/var/spool/cvmfs`` is served by
+an ext3 or ext4 file system. Furthermore, note that OverlayFS cannot fully comply
 with POSIX semantics, in particular hard links must be broken into individual
 files. That is usually not a problem but should be kept in mind when installing
 certain software distributions into a CernVM-FS repository.
@@ -156,10 +150,10 @@ certain software distributions into a CernVM-FS repository.
 Notable CernVM-FS Server Locations and Files
 --------------------------------------------
 
-There are a number of possible customisations in the CernVM-FS server
+There are a number of possible customizations in the CernVM-FS server
 installation. The following table provides an overview of important
-configuration files and intrinsical paths together with some
-customisation hints. For an exhaustive description of the
+configuration files and intrinsic paths together with some
+customization hints. For an exhaustive description of the
 CernVM-FS server infrastructure please consult
 Appendix ":ref:`apx_serverinfra`".
 
@@ -196,7 +190,7 @@ Appendix ":ref:`apx_serverinfra`".
                                          :ref:`this table <tab_configfiles>`. Do
                                          not symlink this directory.
 
-  ``/etc/cvmfs/cvmfs_server_hooks.sh``   **Customisable server behaviour**
+  ``/etc/cvmfs/cvmfs_server_hooks.sh``   **Customizable server behavior**
                                          See ":ref:`sct_serverhooks`" for
                                          further details
 
@@ -229,26 +223,26 @@ A new repository is created by ``cvmfs_server mkfs``:
 
 The utility will ask for a user that should act as the owner of the
 repository and afterwards create all the infrastructure for the new
-CernVM-FS repository. Additionally it will create a reasonable default
+CernVM-FS repository. Additionally, it will create a reasonable default
 configuration and generate a new release manager certificate and
 by default a new master key and corresponding public key (see more
 about that in the next section).
 
 The ``cvmfs_server`` utility will use ``/srv/cvmfs`` as storage location
 by default. In case a separate hard disk should be used, a partition can
-be mounted on /srv/cvmfs or /srv/cvmfs can be symlinked to another
+be mounted on ``/srv/cvmfs`` or ``/srv/cvmfs`` can be symlinked to another
 location (see :ref:`sct_serveranatomy`). Besides local storage it is
-possible to use an :ref:`S3 compatible storage service <sct_s3storagesetup>`
+possible to use a :ref:`S3 compatible storage service <sct_s3storagesetup>`
 as data backend.
 
 Once created, the repository is mounted under ``/cvmfs/my.repo.name``
 containing only a single file called ``new_repository``. The next steps
 describe how to change the repository content.
 
-The repository name resembles a DNS scheme but it does not need to
+The repository name resembles a DNS scheme, but it does not need to
 reflect any real server name. It is supposed to be a globally unique name that
 indicates where/who the publishing of content takes place. A repository name
-must only contain alphanumeric characters plus ``-``, ``_``, and ``.`` and it
+must only contain alphanumeric characters plus ``-``, ``_``, or ``.``, and it
 is limited to a length of 60 characters.
 
 .. _sct_master_keys:
@@ -258,11 +252,11 @@ Master keys
 
 Each cvmfs repository uses two sets of keys, one for the individual
 repository and another called the "masterkey" which signs the
-repository key.  The pub key that corresponds to the masterkey is
+repository key. The pub key that corresponds to the masterkey is
 what needs to be distributed to clients to verify the authenticity of
-the repository.  It is usually most convenient to share the masterkey
+the repository. It is usually most convenient to share the masterkey
 between all repositories in a domain so new repositories can be added
-without updating the client configurations.  If the clients are
+without updating the client configurations. If the clients are
 maintained by multiple organizations it can be very difficult to
 quickly update the distributed pub key, so in that case it is
 important to keep the masterkey especially safe from being stolen.
@@ -282,8 +276,8 @@ Signatures are only good for 30 days by default, so
 ``cvmfs_server`` also supports the ability to store the masterkey in a
 separate inexpensive smartcard, so that even if the computer hosting
 the repositories is compromised, the masterkey cannot be stolen.
-Smartcards allow writing keys into them and signing files but they
-never allow reading the keys back.  Currently the supported hardware
+Smartcards allow writing keys into them and signing files, but they
+never allow reading the keys back. Currently, the supported hardware
 are the Yubikey 4 or Nano USB devices.
 
 If one of those devices is plugged in to a release manager machine,
@@ -296,21 +290,21 @@ this is how to use it:
 
 #. Make a backup copy of ``/etc/cvmfs/keys/my.repo.name.masterkey`` on
     at least one USB flash drive because the next step will
-    irretrievably delete the file.  Keep the flash drive offline in
+    irretrievably delete the file. Keep the flash drive offline in
     a safe place in case something happens to the smartcard.
 
 #. Convert the repository to use the smartcard with
-   ``cvmfs_server masterkeycard -c my.repo.name``.  This will delete
-   the masterkey file.  This command can also be applied to other
+   ``cvmfs_server masterkeycard -c my.repo.name``. This will delete
+   the masterkey file. This command can also be applied to other
    repositories on the same machine; their pub file will be updated
-   with what is stored in the card and they will be resigned.
+   with what is stored in the card, and they will be resigned.
 
 From then on, every newly created repository on the same machine
 will automatically use the shared masterkey stored on the smartcard.
 
 When using a masterkeycard, the default signature expiration reduces
-from 30 days to 7 days.  ``cvmfs_server resign`` needs to be run to
-renew the signature.  It is recommended to run that daily from cron.
+from 30 days to 7 days. ``cvmfs_server resign`` needs to be run to
+renew the signature. It is recommended to run that daily from cron.
 
 
 Repositories for Volatile Files
@@ -335,7 +329,7 @@ Files in the CernVM-FS repository data store are compressed and named
 according to their compressed content hash. The default settings use DEFLATE
 (zlib) for compression and SHA-1 for hashing.
 
-CernVM-FS can optionally skip compression of files.  This can be beneficial,
+CernVM-FS can optionally skip compression of files. This can be beneficial,
 for instance, if the repository is known to contain already compressed content,
 such as JPG images or compressed ROOT files. In order to disable compression,
 set ``CVMFS_COMPRESSION_ALGORITHM=none`` in the
@@ -343,16 +337,15 @@ set ``CVMFS_COMPRESSION_ALGORITHM=none`` in the
 2.2 is required in order to read uncompressed files.
 
 Instead of SHA-1, CernVM-FS can use RIPEMD-160 or SHAKE-128 (a variant of SHA-3
-with 160 output bits) as hash algorithm. In general, we advise not to change the
-default.  In future versions, the default might change from SHA-1 to SHAKE-128.
-In order to enforce the use of a specific hash algorithm, set
+with 160 output bits) as hash algorithm. In general, we do not advise to change the
+default. However, if required, a specific hash algorithm can be enforced by setting
 ``CVMFS_HASH_ALGORITHM=sha1``, ``CVMFS_HASH_ALGORITHM=rmd160``, or
 ``CVMFS_HASH_ALGORITHM=shake128`` in the ``server.conf`` file. Client version
->= 2.1.18 is required for accessing repositories that use RIPEMD-160.  Client
+>= 2.1.18 is required for accessing repositories that use RIPEMD-160. Client
 version >= 2.2 is required for accessing repositories that use SHAKE-128.
 
 Both compression and hash algorithm can be changed at any point during the
-repository life time.  Existing content will remain untouched, new content will
+repository lifetime. Existing content will remain untouched, new content will
 be processed with the new settings.
 
 
@@ -375,17 +368,20 @@ a file ``/foo/bar`` with content hash ``0x1234`` would be addressed as
    $HTTP_SERVER_URL/12/34      # as regular file
    $HTTP_EXTERNAL_URL/foo/bar  # as external file
 
-Note that the content hash of external files is still verified on download. Also
-note that CernVM-FS by itself does not know or store the location of external
-files but it must be explicitly set through the client configuration. On the
-clients, the ``CVMFS_EXTERNAL_URL``, ``CVMFS_EXTERNAL_HTTP_PROXY`` and the other
-"external" parameters are used to configure the external HTTP servers
-(see :ref:`appendix <apxsct_clientparameters>`).
+.. note::
+    The content hash of external files is still verified on download.
+
+.. note::
+    CernVM-FS by itself does not know or store the location of external files.
+    Instead, the location must be explicitly set through the client configuration.
+    On the clients, the ``CVMFS_EXTERNAL_URL``, ``CVMFS_EXTERNAL_HTTP_PROXY`` and the other
+    "external" parameters are used to configure the external HTTP servers
+    (see :ref:`appendix <apxsct_clientparameters>`).
 
 Files are marked as external data if the ``CVMFS_EXTERNAL_DATA`` server
 setting is enabled or if the ``cvmfs_server publish -X`` option is used.
 Conversely, if ``CVMFS_EXTERNAL_DATA`` is set and the
-``cvmfs_server publish -N`` option is used, this particular publish operation
+``cvmfs_server publish -N`` option is used, this particular publish-operation
 will treat its files exceptionally as non-external files.
 
 
@@ -393,23 +389,28 @@ Confidential Repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Repositories can be created with the ``-V`` options or republished with the
-``-F`` option with a ``membership requirement``.  Clients that mount
+``-F`` option with a ``membership requirement``. Clients that mount
 repositories with a membership requirement will grant or deny access to the
-repository based on the decision made by an authorization helper.  See
+repository based on the decision made by an authorization helper. See
 Section :ref:`sct_authz` for details on authorization helpers.
 
 For instance, a repository can be configured to grant access to a repository
-only to those users that have a X.509 certificate with a certain DN.  Note that
-the corresponding client-side X.509 authorization helper is not part of
-CernVM-FS but is provided as a third-party plugin by the Open Science Grid.
+only to those users that have an X.509 certificate with a certain DN.
+
+.. note::
+    The corresponding client-side X.509 authorization helper is not part of
+    CernVM-FS but is provided as a third-party plugin by the Open Science Grid.
 
 A membership requirement makes most sense if the repository is served by an
-HTTPS server that requires client-side authentication.  Note that such
-repositories cannot be replicated to Stratum 1 servers.  Such repositories also
-cannot benefit from site proxies.  Instead, such repositories are either part
-of a (non CernVM-FS) HTTPS content distribution network or they might be
-installed for a small number of users that, for example, require access to
+HTTPS server that requires client-side authentication. Due to the access control,
+such repositories cannot be replicated to Stratum 1 servers, nor benefit from site proxies.
+They tend to be either part of a (non CernVM-FS) HTTPS content distribution network,
+or they might be installed for very few users that, for example, require access to
 licensed software.
+
+.. warning::
+    Confidential repositories cannot be replicated to Stratum 1 servers.
+    They also cannot benefit from site proxies.
 
 .. _sct_s3storagesetup:
 
@@ -429,7 +430,8 @@ The bucket needs to be public for reading and require authorization for writing:
       s3cmd mb s3://<BUCKET NAME>
       s3cmd --acl-public setacl s3://<BUCKET NAME>
 
-Note: if you use the Minio client, the ``download`` bucket policy won't work as a bucket policy.
+.. note::
+    If you use the Minio client, the ``download`` bucket policy won't work as a bucket policy.
 
 Once the bucket is available, the S3 storage settings are given as parameters to
 ``cvmfs_server mkfs`` or ``cvmfs_server add-replica``:
@@ -439,8 +441,8 @@ Once the bucket is available, the S3 storage settings are given as parameters to
       cvmfs_server mkfs -s /etc/cvmfs/.../mys3.conf \
         -w http://mybucket.s3.amazonaws.com my.repo.name
 
-The file "mys3.conf" contains the S3 settings (see :ref: `table below
-<tab_s3confparameters>`). The "-w" option is used define the S3 server URL,
+The file ``mys3.conf`` contains the S3 settings (see :ref: `table below
+<tab_s3confparameters>`). The ``-w`` option is used define the S3 server URL,
 e.g. http://localhost:3128, which is used for accessing the repository's
 backend storage on S3.
 
@@ -483,7 +485,7 @@ backend storage on S3.
 Repository Update
 ~~~~~~~~~~~~~~~~~
 
-Typically a repository publisher does the following steps in order to
+Typically, a repository publisher does the following steps in order to
 create a new revision of a repository:
 
 #. Run ``cvmfs_server transaction`` to switch to a copy-on-write enabled
@@ -507,7 +509,7 @@ In order to see the current set of staged changes, use the ``cvmfs_server diff -
 CernVM-FS supports having more than one repository on a single server
 machine. In case of a multi-repository host, the target repository of a
 command needs to be given as a parameter when running the
-``cvmfs_server`` utility.  Most
+``cvmfs_server`` utility. Most
 ``cvmfs_server`` commands allow for wildcards to do manipulations on
 more than one repository at once, ``cvmfs_server migrate *.cern.ch``
 would migrate all present repositories ending with ``.cern.ch``.
@@ -534,17 +536,18 @@ like
     cvmfs_info http://cvmfs-stratum-zero.cern.ch/cvmfs/cernvm-prod.cern.ch
 
 The ``cvmfs_info`` utility can be downloaded as a stand-alone Perl script
-from the linked github repository.
+from the linked GitHub repository.
 
-The ``cvmfs_info`` utility relies on the repository meta-data as described in
-Chapter :ref:`sct_metainfo`.  It shows timestamp and revision number of the
+The ``cvmfs_info`` utility relies on the repository metadata as described in
+Chapter :ref:`sct_metainfo`. It shows timestamp and revision number of the
 repository on the stratum 0 master server and all replicas, as well as the
-remaining life time of the repository whitelist and the catalog time-to-live.
+remaining lifetime of the repository whitelist and the catalog time-to-live.
 
-**Note:** The ``cvmfs_info`` utility queries stratum servers without passing
-through web proxies.  It is not meant to be used on a large-scale by all
-clients.  On clients, the extended attribute ``revision`` can be used to check
-for the currently active repository state, like
+.. note::
+    The ``cvmfs_info`` utility queries stratum servers without passing
+    through web proxies. It is not meant to be used on a large-scale by all
+    clients. On clients, the extended attribute ``revision`` can be used to check
+    for the currently active repository state, like
 
 ::
 
@@ -566,8 +569,10 @@ tarball at a given subdirectory:
 
 The optional ``--catalog`` switch of the ``ingest`` command is used to
 automatically create a nested file catalog at the base directory where the
-tarball is extracted (see :ref:`sct_nestedcatalogs`). Note that currently the
-:ref:`.cvmfsdirtab file <sct_dirtab>` does not apply to the ingest command.
+tarball is extracted (see :ref:`sct_nestedcatalogs`).
+
+.. warning::
+    Currently, the :ref:`.cvmfsdirtab file <sct_dirtab>` does not apply to the ``ingest`` command.
 
 The ``ingest`` command can also be used for the reverse operation of recursively
 removing a directory tree:
@@ -586,11 +591,11 @@ Grafting Files
 ~~~~~~~~~~~~~~
 
 When a repository is updated, new files are checksummed and copied / uploaded
-to a directory exported to the web.  There are situations where this is not
+to a directory exported to the web. There are situations where this is not
 optimal - particularly, when :doc:`"large-scale" repositories <cpt-large-scale>`
-are used, it may not be pragmatic to copy every file to a single host.  In these
+are used, it may not be pragmatic to copy every file to a single host. In these
 cases, it is possible to "graft" files by creating a special file containing the
-necessary publication data.  When a graft is encountered, the file is published
+necessary publication data. When a graft is encountered, the file is published
 as if it was present on the repository machine: the repository admin is responsible
 for making sure the file's data is distributed accordingly.
 
@@ -626,7 +631,7 @@ The ``graft`` command takes the following options:
   ``-a``      hash algorithm (default: ``SHA-1``) (optional)
 ============= ==================================================
 
-This command outputs both the ``.cvmfsgraft`` file and and zero-length "real" file if
+This command outputs both the ``.cvmfsgraft`` file and zero-length "real" file if
 ``-o`` is used; otherwise, it prints the contents of the ``.cvmfsgraft`` file to ``stdout``.
 A typical invocation would look like this::
 
@@ -645,9 +650,12 @@ Open a template transaction with the ``-T`` option like
 The command clones the existing directory /foo to /bar before the transaction becomes available to writing.
 This can be useful to publish a new directory tree that is almost identical to an existing one,
 for instance to publish a patch release.
-Cloning the existing directory tree is a fast, meta-data only operation.
-Note that template transactions should be used with care -- excessive use can quickly explode the repository size
-with negative consequences such as much increased garbage collection times.
+Cloning the existing directory tree is a fast, metadata only operation.
+
+.. warning::
+    Template transactions must be used with care.
+    Excessive use can quickly explode the repository size with negative consequences,
+    e.g. greatly increased garbage collection times.
 
 
 Variant Symlinks
@@ -660,7 +668,7 @@ default set of CAs at ``/cvmfs/oasis.opensciencegrid.org/mis/certificates``
 but would like to give the sysadmin the ability to override this with their
 own set of CA certificates.
 
-To setup a variant symlink in your repository, create a symlink as follows
+To set up a variant symlink in your repository, create a symlink as follows
 inside a repository transaction:
 
 ::
@@ -678,7 +686,7 @@ you can instead do:
 
 Here, the symlink will evaluate to ``/cvmfs/oasis.opensciencegrid.org/mis/certificates-real``
 by default unless the sysadmin sets ``OSG_CERTIFICATES`` in a configuration file (such as
-``/etc/cvmfs/config.d/oasis.opensciencegrid.org.local``.
+``/etc/cvmfs/config.d/oasis.opensciencegrid.org.local``).
 
 Repository Import
 ~~~~~~~~~~~~~~~~~
@@ -692,13 +700,13 @@ useful to bootstrap a release manager machine for a given file storage.
 creating a fresh (and empty) storage.
 
 During the import it might be necessary to resign the repository's whitelist.
-Usually because the whitelist's expiry date has exceeded. This operations
-requires the corresponding masterkey to be available in `/etc/cvmfs/keys`
+Usually because the whitelist's expiry date has exceeded. This operation
+requires the corresponding masterkey to be available in ``/etc/cvmfs/keys``
 or in a masterkeycard.
 Resigning is enabled by adding ``-r`` to ``cvmfs_server import``.
 
 An import can either use a provided repository keychain placed into
-`/etc/cvmfs/keys` or generate a fresh repository key and certificate for the
+``/etc/cvmfs/keys`` or generate a fresh repository key and certificate for the
 imported repository. The latter case requires an update of the repository's
 whitelist to incorporate the newly generated repository key. To generate a fresh
 repository key add ``-t -r`` to ``cvmfs_server import``.
@@ -773,16 +781,16 @@ Maintaining a CernVM-FS Repository
 ----------------------------------
 
 CernVM-FS is a versioning, snapshot-based file system. Similar to
-versioning systems, changes to /cvmfs/...are temporary until they are
+versioning systems, changes to ``/cvmfs/...`` are temporary until they are
 committed (``cvmfs_server publish``) or discarded
 (``cvmfs_server abort``). That allows you to test and verify changes,
 for instance to test a newly installed release before publishing it to
 clients. Whenever changes are published (committed), a new file system
 snapshot of the current state is created. These file system snapshots
 can be tagged with a name, which makes them *named snapshots*. A named
-snapshot is meant to stay in the file system. One can rollback to named
-snapshots and it is possible, on the client side, to mount any of the
-named snapshots in lieu of the newest available snapshot.
+snapshot is meant to stay in the file system. One can roll back the repository
+to a specific named snapshots. Furthermore, on the client side, any
+named snapshots can be mounted instead of the newest available snapshot.
 
 Two named snapshots are managed automatically by CernVM-FS, ``trunk``
 and ``trunk-previous``. This allows for easy unpublishing of a mistake,
@@ -814,7 +822,7 @@ lot of time::
 
 Optionally ``cvmfs_server check`` can also verify the data integrity
 (command line flag ``-i``) of each data object in the repository. This
-is a time consuming process and we recommend it only for diagnostic
+is a time-consuming process, and we recommend it only for diagnostic
 purposes.
 
 .. _sct_namedsnapshots:
@@ -822,7 +830,7 @@ purposes.
 Named Snapshots
 ~~~~~~~~~~~~~~~
 
-Named snapshots or *tags* are an easy way to organise checkpoints in the
+Named snapshots or *tags* are an easy way to organize checkpoints in the
 file system history. CernVM-FS clients can explicitly mount a repository
 at a specific named snapshot to expose the file system content published
 with this tag. It also allows for rollbacks to previously created and
@@ -851,12 +859,12 @@ By default, new repositories will automatically create a generic tag if
 no explicit tag is given during publish. The automatic tagging can be
 turned off using the ``-g`` option during repository creation or by setting
 ``CVMFS_AUTO_TAG=false`` in the
-/etc/cvmfs/repositories.d/$repository/server.conf file.
+``/etc/cvmfs/repositories.d/$repository/server.conf`` file.
 
-The life time of automatic tags can be restriced by the
+The lifetime of automatic tags can be restricted by the
 ``CVMFS_AUTO_TAG_TIMESPAN`` parameter or by the ``-G`` option to
-``cvmfs_server mkfs``.  The parameter takes a string that the ``date`` utility
-can parse, for instance ``"4 weeks ago"``.  On every publish, automatically
+``cvmfs_server mkfs``. The parameter takes a string that the ``date`` utility
+can parse, for instance ``"4 weeks ago"``. On every publish, automatically
 generated tags older than the defined threshold are removed.
 
 Creating a Named Snapshot
@@ -881,8 +889,8 @@ command. Without any command line parameters, it will print all
 currently available named snapshots. Snapshots can be inspected
 (``-i <tag name>``), removed (``-r <tag name>``) or created
 (``-a <tag name> -m <tag description> -h <catalog root hash>``).
-Furthermore machine readable modes for both listing (``-l -x``) as well
-as inspection (``-i <tag name> -x``) is available.
+Furthermore, machine-readable modes for both listing (``-l -x``) and
+inspection (``-i <tag name> -x``) are available.
 
 Rollbacks
 ^^^^^^^^^
@@ -906,8 +914,9 @@ Unless named snapshots are provided by the ``-s`` and ``-d`` flags, the command
 shows the difference from the last snapshot ("trunk-previous") to the current
 one ("trunk").
 
-Note that the command ``cvmfs_server diff`` shows the changes of the currently
-active transaction.
+.. note::
+    The command ``cvmfs_server diff`` shows the changes of the currently
+    active transaction.
 
 
 .. _sct_instantsnapshotaccess:
@@ -929,7 +938,7 @@ contains the contents of the repository in the state referenced by the snapshot.
 
 To prevent accidental recursion, the top-level directory ``.cvmfs`` is hidden by
 CernVM-FS clients >= 2.4 even for operations that show dot-files like ``ls -a``.
-Clients before version 2.4 will show the ``.cvmfs`` directory but they cannot
+Clients before version 2.4 will show the ``.cvmfs`` directory, but they cannot
 recurse into the named snapshot directories.
 
 
@@ -964,18 +973,19 @@ named snapshot "data-v201708-fix01" in the branch "fixes_data-v201708".
 When publishing a checked out state, it is mandatory to specify a tag name.
 Later, it might be necessary to publish another set of fixes in the same branch.
 To do so, the command ``cvmfs_server checkout -b fixes_data-v201708``
-checks out the latest named snapshot from the given branch.  The command
+checks out the latest named snapshot from the given branch. The command
 ``cvmfs_server checkout`` jumps back to the trunk of the repository.
 
 The command ``cvmfs_server tag -b`` displays the tree of branches and their
-respective initial revisions.  The ``-x`` switch triggers displaying of the tree
+respective initial revisions. The ``-x`` switch triggers displaying of the tree
 in a machines-readable format.
 
 Branching makes most sense for repositories that use the instant snapshot
 access (see Section :ref:`sct_branching`).
 
-Please note that while CernVM-FS supports branching, it does not support
-merging of repository snapshots.
+.. warning::
+    While CernVM-FS supports branching, it does not support merging of
+    repository snapshots.
 
 
 
@@ -984,12 +994,12 @@ merging of repository snapshots.
 Managing Nested Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-CernVM-FS stores meta-data (path names, file sizes, ...) in file catalogs.
+CernVM-FS stores metadata (path names, file sizes, ...) in file catalogs.
 When a client accesses a repository, it has to download the file catalog
-first and then it downloads the files as they are opened. A single file
-catalog for an entire repository can quickly become large and
-impractical. Also, clients typically do not need all of the repository's
-meta-data at the same time. For instance, clients using software release
+first, and then it downloads on-demand the files as they are opened. A single
+file catalog for an entire repository can quickly become large and
+impractical. Also, clients typically do not need all the repository's
+metadata at the same time. For instance, clients using software release
 1.0 do not need to know about the contents of software release 2.0.
 
 With nested catalogs, CernVM-FS has a mechanism to partition the
@@ -1058,7 +1068,7 @@ included in other catalogs.
 It could also make sense to have a nested catalog under
 grid-certificates, if the certificates are updated much more frequently
 than the other directories. It would not make sense to create a nested
-catalog under /cvmfs/experiment.cern.ch/software/i686/common, because
+catalog under ``/cvmfs/experiment.cern.ch/software/i686/common``, because
 this directory needs to be accessed anyway whenever its parent directory
 is needed. As a rule of thumb, a single file catalog should contain more
 than 1000 files and directories but not contain more than
@@ -1113,9 +1123,10 @@ This will create nested catalogs at
     /cvmfs/experiment.cern.ch/software/x86_64/1.0
     /cvmfs/experiment.cern.ch/grid-certificates
 
-Note that unlike the regular lines that add catalogs, asterisks in the
-exclamation point exclusion lines can span the slashes separating
-directory levels.
+.. note::
+    Unlike the regular lines that add catalogs, asterisks in the
+    exclamation point exclusion lines can span the slashes separating
+    directory levels.
 
 Automatic Management of Nested Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1130,8 +1141,8 @@ threshold, or removed if their weight is less than a minimum threshold.
 Automatically generated catalogs contain a ``.cvmfsautocatalog`` file
 (along with the ``.cvmfscatalog`` file) in its root directory.
 User-defined catalogs (containing only a ``.cvmfscatalog`` file) always
-remain untouched. Hence one can mix both manual and automatically
-managed directory sub-trees.
+remain untouched. Hence, one can mix both manual and automatically
+managed directory subtrees.
 
 The following conditions are applied when processing a nested catalog:
 
@@ -1163,7 +1174,7 @@ stated :ref:`here <sct_nestedrecommendations>` the recommended
 maximal file entry count of a single catalog should not exceed
 :math:`\approx`\ 200000. One can use the switch ``list-catalogs -e`` to
 inspect the current nested catalog entry counts in the repository.
-Furthermore ``list-catalogs -s`` will print the file sizes of the
+Furthermore, ``list-catalogs -s`` will print the file sizes of the
 catalogs in bytes.
 
 Repository Mount Point Management
@@ -1181,10 +1192,10 @@ manager machine anymore. Usually the mount point handling happens
 automatically and transparently to the user when invoking arbitrary
 ``cvmfs_server`` commands.
 
-Nevertheless ``cvmfs_server mount <repo name>`` allows users to explicitly
+Nevertheless, ``cvmfs_server mount <repo name>`` allows users to explicitly
 trigger this repair operation anytime for individual repositories. Mounting
 all hosted repositories is possible with the ``-a`` parameter but requires
-root privileges.  If you want to have all hosted repositories mounted after
+root privileges. If you want to have all hosted repositories mounted after
 reboot then put ``cvmfs_server mount -a`` in a boot script, for example in
 ``/etc/rc.local``.
 
@@ -1200,7 +1211,7 @@ Syncing files into a repository with cvmfs_rsync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A common method of publishing into CernVM-FS is to first install all the
-files into a convenient shared filesystem, mount the shared filesystem
+files into a convenient shared file system, mount the shared file system
 on the publishing machine, and then sync the files into the repository
 during a transaction. The most common tool to do the syncing is
 ``rsync``, but ``rsync`` by itself doesn't have a convenient mechanism
@@ -1244,9 +1255,11 @@ In order to run a file catalog migration use ``cvmfs_server migrate``
 for each of the outdated repositories. This will essentially create a
 new repository revision that contains the exact same file structure as
 the current revision. However, all file catalogs will be recreated from
-scratch using the updated internal structure. Note that historic file
-catalogs of all previous repository revisions stay untouched and are not
-migrated.
+scratch using the updated internal structure.
+
+.. note::
+    Historic file catalogs of all previous repository revisions stay untouched
+    and are not migrated!
 
 After ``cvmfs_server migrate`` has successfully updated all file
 catalogs repository maintenance can continue as usual.
@@ -1269,7 +1282,7 @@ a tool to quickly do such adaption on :ref:`CernVM-FS catalog level
   cvmfs_server catalog-chown -u <uid map> -g <gid map> <repo name>
 
 Both the UID and GID map contain a list of rules to apply to each file
-meta data record in the CernVM-FS catalogs. This is an example of such
+metadata record in the CernVM-FS catalogs. This is an example of such
 a rules list::
 
   # map root UID/GID to 1001
@@ -1282,10 +1295,11 @@ a rules list::
   # map everything else to 1004
   * 1004
 
-Note that running ``cvmfs_server catalog-chown`` produces a new repository
-revision containing :ref:`CernVM-FS catalogs <sct_filecatalog>` with updated
-UIDs and GIDs according to the provided rules. Thus, previous revisions of
-the CernVM-FS repository will *not* be affected by this update.
+.. note::
+    Running ``cvmfs_server catalog-chown`` produces a new repository
+    revision containing :ref:`CernVM-FS catalogs <sct_filecatalog>` with updated
+    UIDs and GIDs according to the provided rules. Thus, previous revisions of
+    the CernVM-FS repository will *not* be affected by this update.
 
 .. _sct_repo_stats:
 
@@ -1359,14 +1373,14 @@ Repository Garbage Collection
 Since CernVM-FS is a versioning file system it is following an
 insert-only policy regarding its backend storage. When files are deleted
 from a CernVM-FS repository, they are not automatically deleted from the
-underlying storage. Therefore legacy revisions stay intact and usable
+underlying storage. Therefore, legacy revisions stay intact and usable
 forever (cf. :ref:`sct_namedsnapshots`) at the expense of an
 ever-growing storage volume both on the Stratum 0 and the Stratum 1s.
 
 For this reason, applications that frequently install files into a
 repository and delete older ones - for example the output from nightly
 software builds - might quickly fill up the repository's backend
-storage. Furthermore these applications might actually never make use of
+storage. Furthermore, these applications might actually never make use of
 the aforementioned long-term revision preservation rendering most of the
 stored objects "garbage".
 
@@ -1384,10 +1398,10 @@ The garbage collector of CernVM-FS is using a mark-and-sweep algorithm
 to detect unused files in the internal catalog graph. Revisions that are
 referenced by named snapshots (cf. :ref:`sct_namedsnapshots`) or that
 are recent enough are preserved while all other revisions are condemned
-to be removed. By default this time-based threshold is *three days* but
-can be changed using the configuration variable
+to be removed. The default value of this time-based threshold is *three days*
+but can be changed using the configuration variable
 ``CVMFS_AUTO_GC_TIMESPAN`` both on Stratum 0 and Stratum 1. The value of
-this variable is expected to be parseable by the ``date`` command, for
+this variable is expected to be parsable by the ``date`` command, for
 example ``3 days ago`` or ``1 week ago``.
 
 Enabling Garbage Collection
@@ -1409,11 +1423,11 @@ Enabling Garbage Collection on an Existing Repository (Stratum 0)
 Existing repositories can be reconfigured to be garbage collectable by
 adding
 ``CVMFS_GARBAGE_COLLECTION=true`` and ``CVMFS_AUTO_GC=true`` to the
-``server.conf`` of the repository. Furthermore it is recommended to
+``server.conf`` of the repository. Furthermore, it is recommended to
 switch off automatic tagging by setting ``CVMFS_AUTO_TAG=false`` for a
 garbage collectable repository. The garbage collection will be enabled
 with the next published transaction and will run every once in a while after a
-publish operation.  Alternatively, ``CVMFS_AUTO_GC=false`` may be set and
+publish operation. Alternatively, ``CVMFS_AUTO_GC=false`` may be set and
 ``cvmfs_server gc`` run from cron at a time when no publish
 operations will be happening; garbage collection and publish
 operations cannot happen at the same time.
@@ -1423,8 +1437,8 @@ Enabling Garbage Collection on an Existing Replication (Stratum 1)
 
 In order to use automatic garbage collection on a stratum 1 replica,
 set ``CVMFS_AUTO_GC=true`` in the ``server.conf`` file of the stratum
-1 installation.  This will run the garbage collection every once in a while
-after a snapshot.  It will only work if the upstream stratum 0 repository has
+1 installation. This will run the garbage collection every once in a while
+after a snapshot. It will only work if the upstream stratum 0 repository has
 garbage collection enabled.
 
 Alternatively, all garbage collectable repositories can be automatically
@@ -1435,17 +1449,17 @@ Frequency of the Automatic Garbage Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If ``CVMFS_AUTO_GC=true`` is set, the parameter ``CVMFS_AUTO_GC_LAPSE`` controls
-how frequently automatic garbage collection is executed.  By default,
-``CVMFS_AUTO_GC_LAPSE`` is set to ``1 day ago``.  If, on publish or snapshot,
-the last manual or automatic garbage collection is farther in the past then the
-given threshold, garbage collection will run.  Otherwise it is skipped.
+how frequently automatic garbage collection is executed. By default,
+``CVMFS_AUTO_GC_LAPSE`` is set to ``1 day ago``. If, on publish or snapshot,
+the last manual or automatic garbage collection is farther in the past than the
+given threshold, garbage collection will run. Otherwise, it is skipped.
 
 
 Limitations on Repository Content
 ---------------------------------
 
-Because CernVM-FS provides what appears to be a POSIX filesystem to
-clients, it is easy to think that it is a general purpose filesystem and
+Because CernVM-FS provides what appears to be a POSIX file system to
+clients, it is easy to think that it is a general purpose file system and
 that it will work well with all kinds of files. That is not the case,
 however, because CernVM-FS is optimized for particular types of files
 and usage. This section contains guidelines for limitations on the
@@ -1455,7 +1469,7 @@ Data files
 ~~~~~~~~~~
 
 First and foremost, CernVM-FS is designed to distribute executable code
-that is shared between a large number of jobs that run together at grid
+that is shared between thousands of jobs that run together at grid
 sites, clouds, or clusters. Worker node cache sizes and web proxy
 bandwidth are generally engineered to accommodate that application. The
 total amount read per job is expected to be roughly limited by the
@@ -1469,7 +1483,7 @@ work fine. In addition, if there are files that are larger but read
 slowly throughout long jobs, as opposed to all at once at the beginning,
 that can also work well if the same files are read by many jobs. That is
 because web proxies have to be engineered for handling bursts at the
-beginning of jobs and so they tend to be lightly loaded a majority of
+beginning of jobs, and so they tend to be lightly loaded a majority of
 the time.
 
 As a general rule of thumb, calculate the maximum rate at
@@ -1484,7 +1498,7 @@ disks if the data causes their cache hit ratios to be reduced.
 
 If you need to publish files with much larger working set sizes than
 a typical software environment, refer to :doc:`large-scale repositories <cpt-large-scale>`
-and :doc:`alien caches <cpt-configure.html#alien-cache>`. Using an alien
+and :ref:`alien cache <alien cache>`. Using an alien
 cache is a good way to distribute large data sets when multiple users on the cluster
 are accessing the same data files.
 
@@ -1506,12 +1520,13 @@ Tarballs, zip files, and other archive files
 If the contents of a tarball, zip file, or some other type of archive
 file is desired to be distributed by CernVM-FS, it is usually better to
 first unpack it into its separate pieces first. This is because it
-allows better sharing of content between multiple releases of the file;
-some pieces inside the archive file might change and other pieces might
-not in the next release, and pieces that don't change will be stored as
-the same file in the repository. CernVM-FS will compress the content of
-the individual pieces, so even if there's no sharing between releases it
-shouldn't take much more space.
+allows better sharing of content between multiple releases of the file.
+In most cases, a new release will not change all files within an archive.
+Files that have not changed between releases will just be stored as a single
+file in the CernVM-FS repository with the different releases referencing it.
+As such, only the *delta* between releases is saved. Furthermore, CernVM-FS
+will compress the content of the individual pieces, so even if there is no
+sharing between releases it should not take much more space.
 
 File permissions
 ~~~~~~~~~~~~~~~~
@@ -1520,7 +1535,7 @@ Care should be taken to make all the files in a repository readable by
 "other". This is because permissions on files in the original repository
 are generally the same as those seen by end clients, except the files
 are owned by the "cvmfs" user and group. The write permissions are
-ignored by the client since it is a read-only filesystem. However,
+ignored by the client since it is a read-only file system. However,
 unless the client has set
 
 ::
@@ -1534,17 +1549,17 @@ files in CernVM-FS if they won't be able to be read by anyone.
 
 .. _sct_limit_hardlink:
 
-Hardlinks
-~~~~~~~~~
+Hard Links
+~~~~~~~~~~
 
-CernVM-FS breaks hardlinks on publishing into multiple, independent regular files.
+CernVM-FS breaks hard links on publishing into multiple, independent regular files.
 
 
 Configuration Recommendation by Use Case
 ----------------------------------------
 
 The default configuration of a fresh CernVM-FS repository are tuned for
-production software repositories and maximum compatibility and safety.  For
+production software repositories and maximum compatibility and safety. For
 other typical use cases, the configuration should be adapted.
 
 General Recommendations
@@ -1563,7 +1578,7 @@ and uses the more future-proof SHA-3 derived content hash algorithm.
 Multi-Tenant Repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For repositories that are edited by several, possibly unexperienced users, we
+For repositories that are edited by several, possibly inexperienced users, we
 suggest the following configuration settings::
 
     CVMFS_AUTOCATALOGS=true
@@ -1580,7 +1595,7 @@ Repositories for Software "Nightly Builds"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Repositories containing the result of "nightly builds" are usually subject to a
-lot of churn and accumulate unreferenced objects quickly.  We recommend to
+lot of churn and accumulate unreferenced objects quickly. We recommend to
 set ::
 
     CVMFS_AUTO_TAG=false
@@ -1588,8 +1603,8 @@ set ::
     CVMFS_AUTO_GC=true
 
 in order to activate garbage collection and to turn off CernVM-FS' versioning
-(provided that the content on such repositories is ephemeral).  Instead of
-autmatic garbage collection, one can also install a regular cron job running
+(provided that the content on such repositories is ephemeral). Instead of
+automatic garbage collection, one can also install a regular cron job running
 ``cvmfs_server gc -af``, or the nightly build script should be updated to invoke
 ``cvmfs_server gc <repo name>``.
 
@@ -1612,7 +1627,7 @@ Repositories for Container Images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Repositories containing Linux container image contents (that is: container root
-file systems) should use overlayfs as a union file system and have the following
+file systems) should use OverlayFS as a union file system and have the following
 configuration::
 
     CVMFS_INCLUDE_XATTRS=true

--- a/cpt-repository-gateway.rst
+++ b/cpt-repository-gateway.rst
@@ -150,7 +150,7 @@ Example procedure
 * The publisher is ``publisher.cern.ch``.
 * The new repository's fully qualified name is ``test.cern.ch``.
 * The repository's public key (RSA) is ``test.cern.ch.pub``.
-* The repository's public key (encoded as a X.509 certificate) is ``test.cern.ch.crt``.
+* The repository's public key (encoded as an X.509 certificate) is ``test.cern.ch.crt``.
 * The gateway API key is ``test.cern.ch.gw``.
 * The gateway application is running on port 4929 at the URL
   ``http://gateway.cern.ch:4929/api/v1``.
@@ -269,7 +269,7 @@ format to be accepted: ::
   }
 
 It should be noted that when keys are loaded from a file, an ``id`` field does not need
-to be specified in the configuration file. The public id of the loaded key is
+to be specified in the configuration file. The public ID of the loaded key is
 the one specified in the key file itself.
 
 Legacy repository configuration syntax
@@ -320,7 +320,7 @@ old directories are still present, they can be deleted: ::
 API reference
 =============
 
-This sections describes the HTTP API exposed by the gateway application.
+This section describes the HTTP API exposed by the gateway application.
 
 Repositories
 ************
@@ -868,7 +868,7 @@ Publication workflow
     Pub ->> GW: POST /api/v1/leases/<TOKEN>
     GW ->> Receiver: Commit
 
-    Note right of Receiver: Reconciliate local and remote changes
+    Note right of Receiver: Reconcile local and remote changes
     Note right of Receiver: Create new catalogs up to the repository root
 
     Receiver ->> S0: Upload catalogs

--- a/cpt-servermeta.rst
+++ b/cpt-servermeta.rst
@@ -8,7 +8,7 @@ meta information as JSON data. Release manager machines keep a list of hosted
 Stratum0 and Stratum1 repositories and user-defined administrative meta
 information.
 
-Furthermore each repository contains user-maintained signed meta-information
+Furthermore, each repository contains user-maintained signed meta-information
 that gets replicated to Stratum1 servers automatically.
 
 .. _sct_globalmetainfo:
@@ -22,18 +22,19 @@ automatically generated and can be accessed here::
 
   http://<server base URL>/cvmfs/info/v1/repositories.json
 
-Furthermore there might be user-defined information like the administrator's
+Furthermore, there might be user-defined information like the administrator's
 name, contact information and an arbitrary user-defined JSON portion here::
 
   http://<server base URL>/cvmfs/info/v1/meta.json
 
-Using the  ``cvmfs_server`` utility, an administrator can edit the user-defined
-portion of the data with a text editor (cf. ``$EDITOR``)s::
+Using the ``cvmfs_server`` utility, an administrator can edit the user-defined
+portion of the data with a text editor (cf. ``$EDITOR``)::
 
   cvmfs_server update-info
 
-Note that the ``cvmfs_server`` package requires the ``jq`` utility, which validates
-CVMFS JSON data.
+.. note::
+  The ``cvmfs_server`` package requires the ``jq`` utility, which validates
+  CVMFS JSON data.
 
 Below are :ref:`examples <sct_jsonexamples>` of both the repository list and
 user-defined JSON files.
@@ -41,11 +42,11 @@ user-defined JSON files.
 Repository Specific Meta Information
 ------------------------------------
 
-Each repository contains a JSON object with repository-specific meta data. The
+Each repository contains a JSON object with repository-specific metadata. The
 information is maintained by the repository's owner on the Stratum0 release
 manager machine. It contains the maintainer's contact information, a description
 of the repository's content, the recommended Stratum 0 URL and a list of
-recommended Stratum 1 replica URLs. Furthermore it provides a custom JSON region
+recommended Stratum 1 replica URLs. Furthermore, it provides a custom JSON region
 for arbitrary information.
 
 Note that this JSON file is stored inside CernVM-FS's backend data structure and

--- a/cpt-shrinkwrap.rst
+++ b/cpt-shrinkwrap.rst
@@ -10,7 +10,7 @@ contain a curated subset of the repository.
 
 The CernVM-FS shrinkwrap utility uses ``libcvmfs`` to export repositories
 to a POSIX file tree. This file tree can then be packaged and exported in
-several different ways, such as SquashFS, Docker layers, or TAR file.
+several ways, such as SquashFS, Docker layers, or TAR file.
 The ``cvmfs_shrinkwrap`` utility supports multithreaded copying to increase
 throughput and a file specification to create a subset of a repository.
 
@@ -29,8 +29,8 @@ CernVM-FS Shrinkwrap Layout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The structure used in the Shrinkwrap output mirrors that used internally
-by CernVM-FS. The visible files are hardlinked to a hidden data directory.
-By default ``cvmfs_shrinkwrap`` builds in a base directory (``/tmp/cvmfs``)
+by CernVM-FS. The visible files are hard linked to a hidden data directory.
+By default, ``cvmfs_shrinkwrap`` builds in a base directory (``/tmp/cvmfs``)
 where a directory exists for each repository and a ``.data`` directory
 containing the content-addressed files for deduplication.
 
@@ -66,7 +66,7 @@ systems limit the number of hard links to 64k.
 Specification File
 ~~~~~~~~~~~~~~~~~~
 
-The specification file allows for both positive entries and exlusion statements.
+The specification file allows for both positive entries and exclusion statements.
 Inclusion can be specified directly for each file, can use wildcards for
 directories trees, and an anchor to limit to only the specified directory.
 Directly specify file : ::
@@ -103,8 +103,14 @@ a file named ``sft.cern.ch.spec``. ::
      /lcg/releases/lcgenv/*
 
 Write the ``libcvmfs`` configuration file that will be used for ``cvmfs_shrinkwrap``.
-``cvmfs_shrinkwrap`` puts a heavy load on servers, so please do not configure it to read from production Stratum 1s.
-CERN provides a separate server at http://cvmfs-stratum-zero-hpc.cern.ch and OSG provides one at http://cvmfs-s1goc.opensciencegrid.org:8001.
+
+.. warning::
+   ``cvmfs_shrinkwrap`` puts heavy load on servers. **DO NOT** configure it to read
+   from production Stratum 1s!
+
+   To use ``cvmfs_shrinkwrap`` at CERN please use ``http://cvmfs-stratum-zero-hpc.cern.ch``,
+   and for OSG please use ``http://cvmfs-s1goc.opensciencegrid.org:8001``.
+
 Here is an example that uses the CERN server, written to ``sft.cern.ch.config``. ::
 
     CVMFS_REPOSITORIES=sft.cern.ch
@@ -117,14 +123,15 @@ Here is an example that uses the CERN server, written to ``sft.cern.ch.config``.
     CVMFS_SHARED_CACHE=no # Important as libcvmfs does not support shared caches
     CVMFS_USER=cvmfs
 
-Note: Keys will need to be provided. The location in this configuration is the default used for CVMFS with FUSE.
+.. note::
+   Keys will need to be provided. The location in this configuration is the default used for CVMFS with FUSE.
 
 Using the cvmfs repository ``sft.cern.ch`` : ::
 
     sudo cvmfs_shrinkwrap -r sft.cern.ch -f sft.cern.ch.config -t sft.cern.ch.spec --dest-base /tmp/cvmfs -j 16
 
-Creating an image in userspace
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Creating an image in user space
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Start by using the above setup.
 
@@ -161,7 +168,7 @@ can be used and moved around.
 Exporting image
 ~~~~~~~~~~~~~~~
 
-Having a fully loaded repository, including the hardlinked data, the image can
+Having a fully loaded repository, including the hard linked data, the image can
 be exported to a number of different formats and packages. Some examples of this
 could be ZIP, tarballs, or squashfs. The recommendation is to use squashfs as
 it provides a great amount of portability and is supported for directly mounting
@@ -176,7 +183,7 @@ If tools for creating squashfs are not already available try : ::
    yum install squashfs-tools
 
 
-After this has been install a squashfs image can be created using the above image : ::
+After this has been installed a squashfs image can be created using the above image : ::
 
    mksquashfs /tmp/cvmfs root-sft-image.sqsh
 
@@ -200,8 +207,8 @@ Important note on use
 ~~~~~~~~~~~~~~~~~~~~~
 
 Shrinkwrap images mirror the data organization of CVMFS. As such it is important
-that the data and the filesystem tree be co-located in the filesystem/mountpoint.
-If the data is separated from the filesystem tree you are likely to encounter an
+that the data and the file system tree be co-located in the file system/mountpoint.
+If the data is separated from the file system tree you are likely to encounter an
 error.
 
 

--- a/cpt-squid.rst
+++ b/cpt-squid.rst
@@ -28,14 +28,14 @@ installed you can use it as well for CernVM-FS.
 
 One option that is particularly important when there are a lot of worker
 nodes and jobs that start close together is the `collapsed_forwarding`
-option.  This combines multiple simultaneous requests for the same
-object into a single request to a Stratum 1 server.  This did not work
+option. This combines multiple simultaneous requests for the same
+object into a single request to a Stratum 1 server. This did not work
 properly on squid versions prior to 3.5.28, which includes the default
-squid on EL7.  This also works properly in Frontier Squid.
+squid on EL7. This also works properly in Frontier Squid.
 
 In any case, cache sizes and access control needs to be configured in
 order to use the Squid server with CernVM-FS. In order to do so, browse
-through your /etc/squid/squid.conf and make sure the following lines
+through your ``/etc/squid/squid.conf`` and make sure the following lines
 appear accordingly:
 
 ::
@@ -50,8 +50,8 @@ appear accordingly:
       cache_dir ufs /var/spool/squid 50000 16 256
 
 Furthermore, Squid needs to allow access to all Stratum 1 servers. This
-is controlled through Squid ACLs.  Most sites allow all of their IP
-addresses to connect to any destination address.  By default squid
+is controlled through Squid ACLs. Most sites allow all of their IP
+addresses to connect to any destination address. By default, squid
 allows that for the standard private IP addresses, but if you're not
 using a private network then add your public address ranges, with
 something like this:

--- a/cpt-tracer.rst
+++ b/cpt-tracer.rst
@@ -59,9 +59,9 @@ The following events are known:
 
   4            Lookup path
 
-  5            Get file system meta-data (e.g. df call)
+  5            Get file system metadata (e.g. df call)
 
-  6            Get file/directory meta-data
+  6            Get file/directory metadata
 
   7            List extended attributes of a file/directory
 

--- a/cpt-xcache.rst
+++ b/cpt-xcache.rst
@@ -8,12 +8,13 @@ This page describes how to set up an experimental HTTP reverse proxy
 layer for CernVM-FS based on `Xcache
 <http://xrootd.org/doc/dev47/pss_config.htm>`_.
 
-NOTE: This is not a replacement for a general site forward proxy.
-Forwarding needs to be defined separately in the Xcache configuration
-for each destination Stratum 1, and the client CVMFS_SERVER_URL
-configuration has to point to a separate forwarder URL for each
-server.  This document is for the convenience of people who want to
-experiment with this configuration.
+.. note::
+   This is not a replacement for a general site forward proxy.
+   Forwarding needs to be defined separately in the Xcache configuration
+   for each destination Stratum 1, and the client ``CVMFS_SERVER_URL``
+   configuration has to point to a separate forwarder URL for each
+   server. This document is for the convenience of people who want to
+   experiment with this configuration.
 
 Requirements
 ============
@@ -46,12 +47,12 @@ layer between a CernVM-FS repository and client machines:
 |
 
 **Machine A** contains a CernVM-FS repository, served by default over
-HTTP. An Xcache instance is running on a second machine. By default
+HTTP. An Xcache instance is running on a second machine. By default,
 Xcache can only ingest files from another XRootD instance - we start
 an instance of XRootD on the same machine as the CernVM-FS repository,
 configured to export the repository using the XRootD protocol. The
 following configuration can be used for this instance of XRootD,
-replacing ``<CVMFS_REPOSITORY_NAME>`` with the actually name of the
+replacing ``<CVMFS_REPOSITORY_NAME>`` with the actual name of the
 repository: ::
 
    oss.localroot /srv

--- a/index.rst
+++ b/index.rst
@@ -9,17 +9,17 @@ Welcome to CernVM-FS's documentation!
 What is CernVM-FS?
 ^^^^^^^^^^^^^^^^^^
 
-The CernVM-File System (CernVM-FS) provides a scalable, reliable and low-
+The CernVM File System (CernVM-FS) provides a scalable, reliable and low-
 maintenance software distribution service. It was developed to assist High
 Energy Physics (HEP) collaborations to deploy software on the worldwide-
 distributed computing infrastructure used to run data processing applications.
 CernVM-FS is implemented as a POSIX read-only file system in user space (a
 FUSE module). Files and directories are hosted on standard web servers and
-mounted in the universal namespace ``/cvmfs``.  Internally, CernVM-FS uses
+mounted in the universal namespace ``/cvmfs``. Internally, CernVM-FS uses
 content-addressable storage and Merkle trees in order to maintain file data
-and meta-data. CernVM-FS uses outgoing HTTP connections only, thereby it
+and metadata. CernVM-FS uses outgoing HTTP connections only, thereby it
 avoids most of the firewall issues of other network file systems. It transfers
-data and meta-data on demand and verifies data integrity by cryptographic
+data and metadata on demand and verifies data integrity by cryptographic
 hashes.
 
 By means of aggressive caching and reduction of latency, CernVM-FS focuses


### PR DESCRIPTION
- spell checking (opted for en-US as we have `catalog` and not `catalogue`, opted for `metadata`, unified spelling, opted for `hard link` (google suggested this writing))
- remove a lot of whitespace
- rephrasing some things (where spellchecker complained about missing comma)
- reformatting commands to be written in texttt
- fix broken link/reference
- add language default
- add formatting for `note` and `warning` messsages, transformed some `notes` into `warnings`
- added that `aufs` is not really supported anymore


one thing missing:
`doc-cvmfs/apx-references.rst:80: WARNING: Citation [Dykstra10] is not referenced.`



i did not read anything about what was written. i mainly did pattern matching. probably missed out quite a bit. only reading i did was when the spellchecker complained about something (mainly about setting comma in front of `and`) and trying to read it just didnt make much sense to me.