### PR TITLE
Add github action to build prs

### DIFF
--- a/.github/workflows/pull-request-links.yaml
+++ b/.github/workflows/pull-request-links.yaml
@@ -1,0 +1,22 @@
+# .github/workflows/pull-request-links.yaml
+
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "cvmfs"


### PR DESCRIPTION
https://github.com/cvmfs/doc-cvmfs/pull/199 breaking the latex build showed that it's good to have CI builds for this page. Adding the standard action to build read-the-docs, that should also allow for previews.