### PR TITLE
Add cvmfs-libs to fedora install instructions

### DIFF
--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -48,7 +48,7 @@ To install the CVMFS package run
 
 ::
 
-    sudo dnf install https://ecsft.cern.ch/dist/cvmfs/cvmfs-2.11.0/cvmfs-2.11.0-1.fc34.x86_64.rpm https://ecsft.cern.ch/dist/cvmfs/cvmfs-config/cvmfs-config-default-latest.noarch.rpm
+    sudo dnf install https://ecsft.cern.ch/dist/cvmfs/cvmfs-2.11.0/cvmfs-2.11.0-1.fc34.x86_64.rpm https://ecsft.cern.ch/dist/cvmfs/cvmfs-config/cvmfs-config-default-latest.noarch.rpm http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.11.0/cvmfs-libs-2.11.0-1.fc34.x86_64.rpm
 
 
 Docker Container


### PR DESCRIPTION
The install instructions for fedora requires specifying the path for cvmfs-libs package. 

The current installation fails with 
```
 Problem: conflicting requests
  - nothing provides cvmfs-libs = 2.11.0 needed by cvmfs-2.11.0-1.fc34.x86_64 from @commandline
  ```