### PR TITLE
remove outdated filesystem recommendation

### DIFF
--- a/cpt-replica.rst
+++ b/cpt-replica.rst
@@ -56,8 +56,7 @@ We suggest the following key parameters:
 **Storage**
     RAID-protected storage. The ``cvmfs_server`` utility should have low
     latency to the storage because it runs lots of system calls (``stat()``)
-    against it. For the local storage backends ext3/4 file systems are
-    preferred (rather than XFS).
+    against it.
 
 **Web server**
     A standard Apache server. Directory listing is not required. In


### PR DESCRIPTION
This is more of an issue/discussion but this repo doesn't seem to have issues.
Anyway this line recommending ext3 or 4 over XFS has existed unchanged in the documentation for 8 years and recently made it into the "[Best Practices for CernVM FS in HPC](https://multixscale.github.io/cvmfs-tutorial-hpc-best-practices/)" tutorial, probably reaching many eyes.

If there is a specific reason for preferring ext4 over XFS it should be explained and justified in the documentation. But the fact that it was put in 8 years ago and never updated leads me to believe the information is likely stale. A great deal has changed in that time, including extensive improvements and engineering efforts going into XFS and likely ext4 as well. To remain valid as a recommendation, some current benchmarking (or other clarifying information) would be needed.
One can find endless debates about ext4 vs XFS but all in all they both seem fine these days. If one foresees a need to shrink a filesystem, use ext4. XFS seems better for more parallel IO streams (which I would think should favour CVMFS) whereas ext4 may be better for single streams.

But in particular nobody should be recommending ext3 anymore!  Unless there is forthcoming information to justify this recommendation I would suggest removing it.    @jblomer @DrDaveD ?
