### PR TITLE
Fix the reload command, -c goes after reload

### DIFF
--- a/cpt-configure.rst
+++ b/cpt-configure.rst
@@ -1096,7 +1096,7 @@ Hotpatching has to be done for all repositories concurrently by
 
 ::
 
-      cvmfs_config [-c] reload
+      cvmfs_config reload [-c]
 
 The optional parameter ``-c`` specifies if the CernVM-FS cache should be
 wiped out during the hotpatch. Reloading of the parameters of a specific


### PR DESCRIPTION
Running `cvmfs_config -c reload` shows the usage:

```
Common configuration tasks for CernVM-FS
Usage: /usr/bin/cvmfs_config <command>
Commands are
  setup [nouser] [nocfgmod] [nostart] [noautofs]
  chksetup
  showconfig [-s(hort output, only non-empty parameters)] [<repository>]
  stat [-v | <repository>]
  status
  probe [<repository list>]
  fsck [-q(uick check for zero byte files only) | <cvmfs_fsck options>]
  fuser <repository>
  reload [-c | <repository>]
  umount
  wipecache
  killall
  bugreport
```