### PR TITLE
docs: note that publish is needed before manual GC

### DIFF
--- a/apx-parameters.rst
+++ b/apx-parameters.rst
@@ -227,6 +227,8 @@ CVMFS_FILE_MBYTE_LIMIT              | Maximum number of megabytes for a publishe
 CVMFS_FORCE_REMOUNT_WARNING         | Enable/disable warning through ``wall`` and grace period before forcefully
                                     | remounting a CernVM-FS repository on the release managere machine.
 CVMFS_GARBAGE_COLLECTION            Enables repository garbage collection |br| (Stratum~0 only | if set to *true*)
+                                    | A publish operation is needed after changing this setting to update
+                                    | the repository manifest before garbage collection can run.
 CVMFS_GC_DELETION_LOG               | Log file path to track all garbage collected objects during sweeping
                                     | for bookkeeping or debugging
 CVMFS_GEO_DB_FILE                   Path to externally updated location of geolite2 city database, or 'None' for no database.

--- a/cpt-repo.rst
+++ b/cpt-repo.rst
@@ -1436,6 +1436,15 @@ publish operation. Alternatively, ``CVMFS_AUTO_GC=false`` may be set and
 operations will be happening; garbage collection and publish
 operations cannot happen at the same time.
 
+.. note::
+
+    If you plan to run ``cvmfs_server gc`` manually (instead of relying on
+    ``CVMFS_AUTO_GC``), you must first publish a transaction after setting
+    ``CVMFS_GARBAGE_COLLECTION=true``. The garbage collection flag is stored
+    in the repository manifest and is only updated during a publish operation.
+    Without this step, ``cvmfs_server gc`` will fail with
+    "repository does not allow garbage collection".
+
 Enabling Garbage Collection on an Existing Replication (Stratum 1)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
At the weekend I ran GC on lhcb.cern.ch which normally has `CVMFS_GARBAGE_COLLECTION=false`. While I figured it out, I think the docs could be clearer about what is wrong so I'm making this PR to suggest an improvement. Feel free to close if you'd leave things as-is or handle it a different way.

See also: https://github.com/cvmfs/cvmfs/pull/4115