### PR TITLE
Convert all tables in apx to markdown definitions lists and provide a nice desplay with css.

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -78,7 +78,8 @@ dd {
 }
 
 /* Lay out parameter-page definition lists like two-column rows */
-.rst-content h1#cernvm-fs-parameters ~ dl {
+.rst-content h1#cernvm-fs-parameters ~ dl ,
+.rst-content h1#available-packages ~ dl {
     display: grid;
     grid-template-columns: minmax(18ch, 32ch) minmax(0, 1fr);
     column-gap: 0;
@@ -86,28 +87,36 @@ dd {
 }
 
 .rst-content h1#cernvm-fs-parameters ~ dl > dt,
-.rst-content h1#cernvm-fs-parameters ~ dl > dd {
+.rst-content h1#cernvm-fs-parameters ~ dl > dd ,
+.rst-content h1#available-packages ~ dl > dt,
+.rst-content h1#available-packages ~ dl > dd {
     margin: 0 !important;
     padding: 0.5rem 0.85rem;
 }
 
 .rst-content h1#cernvm-fs-parameters ~ dl > dt:nth-of-type(odd),
-.rst-content h1#cernvm-fs-parameters ~ dl > dd:nth-of-type(odd) {
+.rst-content h1#cernvm-fs-parameters ~ dl > dd:nth-of-type(odd) ,
+.rst-content h1#available-packages ~ dl > dt:nth-of-type(odd),
+.rst-content h1#available-packages ~ dl > dd:nth-of-type(odd) {
     background-color: #f5f5f5;
 }
 
 .rst-content h1#cernvm-fs-parameters ~ dl > dt:nth-of-type(even),
-.rst-content h1#cernvm-fs-parameters ~ dl > dd:nth-of-type(even) {
+.rst-content h1#cernvm-fs-parameters ~ dl > dd:nth-of-type(even) ,
+.rst-content h1#available-packages ~ dl > dt:nth-of-type(even),
+.rst-content h1#available-packages ~ dl > dd:nth-of-type(even) {
     background-color: #fbfbfb;
 }
 
-.rst-content h1#cernvm-fs-parameters ~ dl > dt {
+.rst-content h1#cernvm-fs-parameters ~ dl > dt ,
+.rst-content h1#available-packages ~ dl > dt {
     grid-column: 1;
     overflow-wrap: anywhere;
     border-radius: 4px 0 0 4px;
 }
 
-.rst-content h1#cernvm-fs-parameters ~ dl > dt .parameter-permalink {
+.rst-content h1#cernvm-fs-parameters ~ dl > dt .parameter-permalink ,
+.rst-content h1#available-packages ~ dl > dt .parameter-permalink {
     margin-left: 0.35em;
     color: #8a8a8a;
     text-decoration: none !important;
@@ -118,11 +127,14 @@ dd {
 }
 
 .rst-content h1#cernvm-fs-parameters ~ dl > dt:hover .parameter-permalink,
-.rst-content h1#cernvm-fs-parameters ~ dl > dt .parameter-permalink:focus {
+.rst-content h1#cernvm-fs-parameters ~ dl > dt .parameter-permalink:focus ,
+.rst-content h1#available-packages ~ dl > dt:hover .parameter-permalink,
+.rst-content h1#available-packages ~ dl > dt .parameter-permalink:focus {
     opacity: 0.9;
 }
 
-.rst-content h1#cernvm-fs-parameters ~ dl > dd {
+.rst-content h1#cernvm-fs-parameters ~ dl > dd ,
+.rst-content h1#available-packages ~ dl > dd {
     grid-column: 2;
     min-width: 0;
     border-left: 1px solid #e9e9e9;
@@ -130,22 +142,27 @@ dd {
 }
 
 @media screen and (max-width: 760px) {
-    .rst-content h1#cernvm-fs-parameters ~ dl {
+    .rst-content h1#cernvm-fs-parameters ~ dl, 
+    .rst-content h1#available-packages ~ dl {
         grid-template-columns: minmax(0, 1fr);
         row-gap: 0.25rem;
     }
 
     .rst-content h1#cernvm-fs-parameters ~ dl > dt,
-    .rst-content h1#cernvm-fs-parameters ~ dl > dd {
+    .rst-content h1#cernvm-fs-parameters ~ dl > dd ,
+    .rst-content h1#available-packages ~ dl > dt,
+    .rst-content h1#available-packages ~ dl > dd {
         grid-column: 1;
     }
 
-    .rst-content h1#cernvm-fs-parameters ~ dl > dt {
+    .rst-content h1#cernvm-fs-parameters ~ dl > dt, 
+    .rst-content h1#available-packages ~ dl > dt {
         margin-top: 1em !important;
         border-radius: 4px 4px 0 0;
     }
 
-    .rst-content h1#cernvm-fs-parameters ~ dl > dd {
+    .rst-content h1#cernvm-fs-parameters ~ dl > dd, 
+    .rst-content h1#available-packages ~ dl > dd {
         border-left: 0;
         border-top: 1px solid #e9e9e9;
         border-radius: 0 0 4px 4px;

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -233,7 +233,7 @@ dd {
 /* Lay out parameter-page definition lists like three-column rows */
 .rst-content h1#cernvm-fs-server-infrastructure ~ dl {
     display: grid;
-    grid-template-columns: minmax(20ch, 28ch) minmax(14ch, 18ch) minmax(0, 1fr);
+    grid-template-columns: minmax(20ch, 30ch) minmax(14ch, 18ch) minmax(0, 1fr);
     column-gap: 0;
     row-gap: 0.5rem;
 }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -213,7 +213,109 @@ dd {
         margin-bottom: 0.75em !important;
     }
 }
+/* Lay out parameter-page definition lists like three-column rows */
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl {
+    display: grid;
+    grid-template-columns: minmax(20ch, 28ch) minmax(14ch, 18ch) minmax(0, 1fr);
+    column-gap: 0;
+    row-gap: 0.5rem;
+}
 
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt,
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd {
+    margin: 0 !important;
+    padding: 0.5rem 0.85rem;
+}
+
+/* Grid placement */
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt {
+    grid-column: 1;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(odd) {
+    grid-column: 2;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(even) {
+    grid-column: 3;
+}
+
+/* Row styling - using index-based grouping */
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt:nth-of-type(odd),
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(4n+1),
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(4n+2) {
+    background-color: #f5f5f5;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt:nth-of-type(even),
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(4n+3),
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(4n+4) {
+    background-color: #fbfbfb;
+}
+
+/* Border styling */
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt {
+    overflow-wrap: anywhere;
+    border-radius: 4px 0 0 4px;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(odd) {
+    min-width: 0;
+    border-left: 1px solid #e9e9e9;
+    border-right: 1px solid #e9e9e9;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(even) {
+    min-width: 0;
+    border-radius: 0 4px 4px 0;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt .parameter-permalink {
+    margin-left: 0.35em;
+    color: #8a8a8a;
+    text-decoration: none !important;
+    font-weight: normal;
+    font-size: 0.85em;
+    opacity: 0.45;
+    transition: opacity 0.15s ease-in-out;
+}
+
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt:hover .parameter-permalink,
+.rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt .parameter-permalink:focus {
+    opacity: 0.9;
+}
+
+@media screen and (max-width: 760px) {
+    .rst-content h1#cernvm-fs-server-infrastructure ~ dl {
+        grid-template-columns: minmax(0, 1fr);
+        row-gap: 0.25rem;
+    }
+
+    .rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt,
+    .rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd {
+        grid-column: 1 !important;
+    }
+
+    .rst-content h1#cernvm-fs-server-infrastructure ~ dl > dt {
+        margin-top: 1em !important;
+        border-radius: 4px 4px 0 0;
+    }
+
+    .rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(odd) {
+        border-left: 0;
+        border-right: 0;
+        border-top: 1px solid #e9e9e9;
+        border-bottom: 1px solid #e9e9e9;
+        border-radius: 0;
+    }
+
+    .rst-content h1#cernvm-fs-server-infrastructure ~ dl > dd:nth-of-type(even) {
+        border-left: 0;
+        border-top: 1px solid #e9e9e9;
+        border-radius: 0 0 4px 4px;
+        margin-bottom: 0.75em !important;
+    }
+}
 /* Style the reference anchors */
 dt a[id] {
     color: inherit !important;

--- a/docs/apx-serverinfra.md
+++ b/docs/apx-serverinfra.md
@@ -115,15 +115,30 @@ certificate, `<fqrn>.key` for the repository's private key and
 `<fqrn>.pub` for the public key. All of those files can be symlinked
 somewhere else if necessary.
 
-  **File Path**                        **Description**
-  ------------------------------------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  `/etc/cvmfs/repositories.d`          **CernVM-FS server config directory** This contains the configuration directories for individual CernVM-FS repositories. Note that this path is shortened using `/.../repos.d/` in the rest of this table.
-  `/.../repos.d/<fqrn>`                **Config directory for specific repo** This contains the configuration files for one specific CernVM-FS repository server.
-  `/.../repos.d/<fqrn>/server.conf`    **Server configuration file** Authoriative configuration file for the CernVM-FS server tools. This file should only contain valid server configuration variables
-                                       as described in the [server parameters appendix](apx-parameters.md#server-parameters), as it controls the behaviour of the CernVM-FS server operations like publishing, pulling and so forth.
-  `/.../repos.d/<fqrn>/client.conf`    **Client configuration file** Authoriative configuration file for the CernVM-FS client used to mount the latest revision of a Stratum 0 release manager machine. This file should only contain valid client configuration
-                                       variables from the [client parameters appendix](apx-parameters.md#client-parameters). This file must not exist for Stratum 1 repositories.
-  `/.../repos.d/<fqrn>/replica.conf`   **Replication configuration file** Contains configuration variables for Stratum 1 specific repositories. This file must not exist for Stratum 0 repositories.
+**File Path**
+:   **Description**
+:   **Details**
+
+---
+`/etc/cvmfs/repositories.d`
+:   **CernVM-FS server config directory**
+:   This contains the configuration directories for individual CernVM-FS repositories. Note that this path is shortened using `/.../repos.d/` in the rest of this table.
+
+`/.../repos.d/<fqrn>`
+:   **Config directory for specific repo**
+:   This contains the configuration files for one specific CernVM-FS repository server.
+
+`/.../repos.d/<fqrn>/server.conf`
+:   **Server configuration file**
+:   Authoriative configuration file for the CernVM-FS server tools. This file should only contain valid server configuration variables as described in the [server parameters appendix](apx-parameters.md#server-parameters), as it controls the behaviour of the CernVM-FS server operations like publishing, pulling and so forth.
+
+`/.../repos.d/<fqrn>/client.conf`
+:   **Client configuration file**
+:   Authoriative configuration file for the CernVM-FS client used to mount the latest revision of a Stratum 0 release manager machine. This file should only contain valid client configuration variables from the [client parameters appendix](apx-parameters.md#client-parameters). This file must not exist for Stratum 1 repositories.
+
+`/.../repos.d/<fqrn>/replica.conf`
+:   **Replication configuration file**
+:   Contains configuration variables for Stratum 1 specific repositories. This file must not exist for Stratum 0 repositories.
 
 ## Environment Setup
 

--- a/docs/apx-serverinfra.md
+++ b/docs/apx-serverinfra.md
@@ -71,15 +71,39 @@ the spool area can grow very large for massive repository updates since
 it contains the writable union file system branch and a CernVM-FS client
 cache directory.
 
-  **File Path**                             **Description**
-  ----------------------------------------- ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  `/var/spool/cvmfs`                        **CernVM-FS server spool area** Contains administrative and scratch space for CernVM-FS repositories. This directory should only contain directories corresponding to individual CernVM-FS repositories.
-  `/var/spool/cvmfs/<fqrn>`                 **Individual repository spool area** Contains the spool area of an individual repository and might temporarily contain large data volumes during massive repository updates. This location can be mounted or symlinked to other locations. Furthermore it must be writable by the repository owner.
-  `/var/spool/cvmfs/<fqrn>/cache`           **CernVM-FS client cache directory** Contains the cache of the CernVM-FS client mounting the r/o branch (i.e. `/var/spool/cvmfs/<fqrn>/rdonly`) of the union file system mount point located at `/cvmfs/<fqrn>`. The content of this directory is fully managed by the CernVM-FS client and hence must be configured as a CernVM-FS cache and writable for the repository owner.
-  `/var/spool/cvmfs/<fqrn>/rdonly`          **CernVM-FS client mount point** Serves as the mount point of the CernVM-FS client exposing the latest published state of the CernVM-FS repository. It needs to be owned by the repository owner and should be empty if CernVM-FS is not mounted to it.
-  `/var/spool/cvmfs/<fqrn>/scratch`         **Writable union file system scratch area** All file system changes applied to `/cvmfs/<fqrn>` during a transaction will be stored in this directory. Hence, it potentially needs to accommodate a large data volume during massive repository updates. Furthermore it needs to be writable by the repository owner.
-  `/var/spool/cvmfs/<fqrn>/tmp`             **Temporary scratch location** Some CernVM-FS server operations like publishing store temporary data files here, hence it needs to be writable by the repository owner. If the repository is idle this directory should be empty.
-  `/var/spool/cvmfs/<fqrn>/client.config`   **CernVM-FS client configuration** This contains client configuration variables for the CernVM-FS client mounted to `/var/spool/cvmfs/<fqrn>/rdonly`. Most notibly it needs to contain `CVMFS_ROOT_HASH` configured to the latest revision published in the corresponding repository. This file needs to be writable by the repository owner.
+**File Path**
+:   **Description**
+:   **Details**
+
+---
+
+`/var/spool/cvmfs`
+:   **CernVM-FS server spool area**
+:   Contains administrative and scratch space for CernVM-FS repositories. This directory should only contain directories corresponding to individual CernVM-FS repositories.
+
+`/var/spool/cvmfs/<fqrn>`
+:   **Individual repository spool area**
+:   Contains the spool area of an individual repository and might temporarily contain large data volumes during massive repository updates. This location can be mounted or symlinked to other locations. Furthermore it must be writable by the repository owner.
+
+`/var/spool/cvmfs/<fqrn>/cache`
+:   **CernVM-FS client cache directory**
+:   Contains the cache of the CernVM-FS client mounting the r/o branch (i.e. `/var/spool/cvmfs/<fqrn>/rdonly`) of the union file system mount point located at `/cvmfs/<fqrn>`. The content of this directory is fully managed by the CernVM-FS client and hence must be configured as a CernVM-FS cache and writable for the repository owner.
+
+`/var/spool/cvmfs/<fqrn>/rdonly`
+:   **CernVM-FS client mount point**
+:   Serves as the mount point of the CernVM-FS client exposing the latest published state of the CernVM-FS repository. It needs to be owned by the repository owner and should be empty if CernVM-FS is not mounted to it.
+
+`/var/spool/cvmfs/<fqrn>/scratch`
+:   **Writable union file system scratch area**
+:   All file system changes applied to `/cvmfs/<fqrn>` during a transaction will be stored in this directory. Hence, it potentially needs to accommodate a large data volume during massive repository updates. Furthermore it needs to be writable by the repository owner.
+
+`/var/spool/cvmfs/<fqrn>/tmp`
+:   **Temporary scratch location**
+:   Some CernVM-FS server operations like publishing store temporary data files here, hence it needs to be writable by the repository owner. If the repository is idle this directory should be empty.
+
+`/var/spool/cvmfs/<fqrn>/client.config`
+:   **CernVM-FS client configuration**
+:   This contains client configuration variables for the CernVM-FS client mounted to `/var/spool/cvmfs/<fqrn>/rdonly`. Most notibly it needs to contain `CVMFS_ROOT_HASH` configured to the latest revision published in the corresponding repository. This file needs to be writable by the repository owner.
 
 ## Repository Configuration Directory
 

--- a/docs/apx-serverinfra.md
+++ b/docs/apx-serverinfra.md
@@ -27,15 +27,39 @@ storage can either be a file system at `/srv/cvmfs` or an S3 compatible
 object storage system (see [S3 compatible storage systems](cpt-repo.md#s3-compatible-storage-systems) for details). In the former case the contents of
 `/srv/cvmfs` are as follows:
 
-  **File Path**                         **Description**
-  ------------------------------------- ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  `/srv/cvmfs`                          **Central repository storage location** Can be mounted or symlinked to another location *before* creating the first repository.
-  `/srv/cvmfs/<fqrn>`                   **Storage location of a specific repository** Can be symlinked to another location *before* creating the repository `<fqrn>`. This location needs to be both writable by the repository owner and accessible through an HTTP server.
-  `/srv/cvmfs/<fqrn>/.cvmfspublished`   **Manifest file of the repository** The manifest provides the entry point into the repository. It is the only file that needs to be signed by the repository's private key.
-  `/srv/cvmfs/<fqrn>/.cvmfswhitelist`   **List of trusted repository certificates** Contains a list of certificate fingerprints that should be allowed to sign a repository manifest (see .cvmfspublished). The whitelist needs to be signed by a globally trusted private key.
-  `/srv/cvmfs/<fqrn>/data`              **CAS location of the repository** Data storage of the repository. Contains catalogs, files, file chunks, certificates and history databases in a content addressable file format. This directory and all its contents need to be writable by the repository owner.
-  `/srv/cvmfs/<fqrn>/data/00..ff`       **Second CAS level directories** Splits the flat CAS namespace into multiple directories. First two digits of the file content hash defines the directory the remainder is used as file name inside the corresponding directory.
-  `/srv/cvmfs/<fqrn>/data/txn`          **CAS transaction directory** Stores partial files during creation. Once writing has completed, the file is committed into the CAS using an atomic rename operation.
+**File Path**
+:   **Description**
+:   **Details**
+
+---
+
+`/srv/cvmfs`
+:   **Central repository storage location**
+:   Can be mounted or symlinked to another location *before* creating the first repository.
+
+`/srv/cvmfs/<fqrn>`
+:   **Storage location of a specific repository**
+:   Can be symlinked to another location *before* creating the repository `<fqrn>`. This location needs to be both writable by the repository owner and accessible through an HTTP server.
+
+`/srv/cvmfs/<fqrn>/.cvmfspublished`
+:   **Manifest file of the repository**
+:   The manifest provides the entry point into the repository. It is the only file that needs to be signed by the repository's private key.
+
+`/srv/cvmfs/<fqrn>/.cvmfswhitelist`
+:   **List of trusted repository certificates**
+:   Contains a list of certificate fingerprints that should be allowed to sign a repository manifest (see .cvmfspublished). The whitelist needs to be signed by a globally trusted private key.
+
+`/srv/cvmfs/<fqrn>/data`
+:   **CAS location of the repository**
+:   Data storage of the repository. Contains catalogs, files, file chunks, certificates and history databases in a content addressable file format. This directory and all its contents need to be writable by the repository owner.
+
+`/srv/cvmfs/<fqrn>/data/00..ff`
+:   **Second CAS level directories**
+:   Splits the flat CAS namespace into multiple directories. First two digits of the file content hash defines the directory the remainder is used as file name inside the corresponding directory.
+
+`/srv/cvmfs/<fqrn>/data/txn`
+:   **CAS transaction directory**
+:   Stores partial files during creation. Once writing has completed, the file is committed into the CAS using an atomic rename operation.
 
 ## Server Spool Area of a Repository (Stratum0)
 


### PR DESCRIPTION
The intention is to create a uniform display within apx of the multiple lists converting the tables to md definition lists, and applying the appropriate css.

The Parameter Descriptions section is the guide, and now all definition lists within appendix are aligned.