### PR TITLE
Fix dead external links in the documentation

### DIFF
--- a/docs/cpt-configure.md
+++ b/docs/cpt-configure.md
@@ -297,7 +297,7 @@ application similar to gdb sandboxes. But instead of debugging the
 application, parrot transparently rewrites file system calls and can
 effectively provide <code class="cvmfs-inline-path">/cvmfs</code> to an application. We recommend using the
 [latest precompiled
-parrot](http://ccl.cse.nd.edu/software/downloadfiles.php), which has
+parrot](https://cctools.readthedocs.io/en/latest/install/), which has
 CernVM-FS support built-in.
 
 In order to sandbox a command `<CMD>` with options `<OPTIONS>` in

--- a/docs/cpt-containers.md
+++ b/docs/cpt-containers.md
@@ -82,7 +82,7 @@ that on every node one pod exposes <code class="cvmfs-inline-path">/cvmfs</code>
 use the cvmfs service container.
 
 Alternatively, a
-[CSI-plugin](https://clouddocs.web.cern.ch/containers/tutorials/cvmfs.html#kubernetes)
+[CSI-plugin](https://github.com/cvmfs-contrib/cvmfs-csi)
 makes it simple to mount a repository inside a Kubernetes managed
 container. The plugin is distributed and available to the CERN
 Kubernetes managed clusters.

--- a/docs/cpt-hpc.md
+++ b/docs/cpt-hpc.md
@@ -18,7 +18,7 @@ section.
 ## Parrot-Mounted CernVM-FS instead of Fuse Module
 
 Instead of accessing <code class="cvmfs-inline-path">/cvmfs</code> through a Fuse module, processes can use
-the [Parrot connector](http://cernvm.cern.ch/portal/filesystem/parrot).
+the [Parrot connector](https://cctools.readthedocs.io/en/latest/parrot/).
 The parrot connector works on x86_64 Linux if the `ptrace` system call
 is not disabled. In contrast to a plain copy of a CernVM-FS repository
 to a shared file system, this approach has the following advantages:
@@ -117,7 +117,7 @@ into the same cache directory.
 ### Access from the Nodes
 
 In order to access a preloaded cache from the nodes, [set the path to
-the directory](http://cernvm.cern.ch/portal/filesystem/parrot) as an
+the directory](cpt-configure.md#alien-cache) as an
 *Alien Cache*. Since there won't be cache misses, parrot or fuse
 clients do not need to download additional files from the network.
 

--- a/docs/cpt-replica.md
+++ b/docs/cpt-replica.md
@@ -199,7 +199,7 @@ no database will be required, but note that this will break the client
 Geo API so only use it for testing, when the server is not used by
 production clients. If the database is installed in the default
 directory used by Maxmind's own
-[geoipupdate](https://dev.maxmind.com/geoip/geoipupdate/) tool,
+[geoipupdate](https://github.com/maxmind/geoipupdate) tool,
 `/usr/share/GeoIP`, then `cvmfs_server` will use it from there and
 neither variable needs to be set.
 

--- a/docs/cpt-xcache.md
+++ b/docs/cpt-xcache.md
@@ -1,7 +1,7 @@
 # Setting up an Xcache reverse proxy
 This page describes how to set up an experimental HTTP reverse proxy
 layer for CernVM-FS based on
-[Xcache](http://xrootd.org/doc/dev47/pss_config.htm).
+[Xcache](https://xrootd.web.cern.ch/doc/dev6/pss_config.htm).
 
 !!! note
 


### PR DESCRIPTION
While looking at cvmfs/cvmfs#4179 I checked the other links in the docs as well.

That link (the parrot connector on the HPC page) turned out to be one of several that return 404 after the sites they point to were restructured, so this updates six of them: the two parrot links in the HPC chapter and the CCTools download link, the XRootD 4.7 reference (now the proxy configuration reference for release 6.0 and above), the retired MaxMind geoipupdate page (now the tool's repository, which documents the /usr/share/GeoIP default), and the CERN cloud docs Kubernetes tutorial, which no longer exists. That last one now points to the CSI driver repository, since the current CERN Kubernetes documentation requires a login; happy to use a different target if you prefer an internal one.

The same dead links also appear in doc/hpc.md and doc/parrot.md in the main repository; I can send a follow-up there if those files are still kept.

`mkdocs build --strict` passes locally.

Fixes cvmfs/cvmfs#4179
